### PR TITLE
fix build with different dconf APIs

### DIFF
--- a/capplets/common/dconf-util.c
+++ b/capplets/common/dconf-util.c
@@ -37,9 +37,9 @@ static DConfClient *
 dconf_util_client_get (void)
 {
 #ifdef HAVE_DCONF_0_13
-    return dconf_client_new ();
-#else
     return dconf_client_new (NULL, NULL, NULL, NULL);
+#else
+    return dconf_client_new ();
 #endif
 }
 
@@ -52,9 +52,9 @@ dconf_util_write_sync (const gchar  *key,
     DConfClient *client = dconf_util_client_get ();
 
 #ifdef HAVE_DCONF_0_13
-    ret = dconf_client_write_sync (client, key, value, NULL, NULL, error);
-#else
     ret = dconf_client_write (client, key, value, NULL, NULL, error);
+#else
+    ret = dconf_client_write_sync (client, key, value, NULL, NULL, error);
 #endif
 
     g_object_unref (client);
@@ -70,9 +70,9 @@ dconf_util_recursive_reset (const gchar  *dir,
     DConfClient *client = dconf_util_client_get ();
 
 #ifdef HAVE_DCONF_0_13
-    ret = dconf_client_write_sync (client, dir, NULL, NULL, NULL, error);
-#else
     ret = dconf_client_write (client, dir, NULL, NULL, NULL, error);
+#else
+    ret = dconf_client_write_sync (client, dir, NULL, NULL, NULL, error);
 #endif
 
     g_object_unref (client);


### PR DESCRIPTION
The dconf_client_new () and dconf_client_write_sync() used in dconf 0.10, not in 0.13.
