### PR TITLE
change INCLUDES to AM_CPPFLAGS for automake-1.13

### DIFF
--- a/capplets/about-me/Makefile.am
+++ b/capplets/about-me/Makefile.am
@@ -41,7 +41,7 @@ desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 uidir   = $(pkgdatadir)/ui
 ui_DATA = $(ui_files)
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(LIBEBOOK_CFLAGS) \
 	-DDATADIR="\"$(datadir)\"" \

--- a/capplets/accessibility/at-properties/Makefile.am
+++ b/capplets/accessibility/at-properties/Makefile.am
@@ -19,7 +19,7 @@ pixmap_DATA =					\
 uidir = $(pkgdatadir)/ui
 ui_DATA = at-enable-dialog.ui
 
-INCLUDES   = $(AT_CAPPLET_CFLAGS)     \
+AM_CPPFLAGS   = $(AT_CAPPLET_CFLAGS)     \
              $(MATECC_CAPPLETS_CFLAGS) \
 	     -DUIDIR=\""$(uidir)"\" \
 	     -DPIXMAPDIR=\""$(pixmapdir)"\" \

--- a/capplets/appearance/Makefile.am
+++ b/capplets/appearance/Makefile.am
@@ -45,7 +45,7 @@ gtkbuilderdir = $(pkgdatadir)/ui
 pixmapdir = $(pkgdatadir)/pixmaps
 wallpaperdir = $(datadir)/mate-background-properties
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MARCO_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(FONT_CAPPLET_CFLAGS) \

--- a/capplets/common/Makefile.am
+++ b/capplets/common/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST =
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""				\
 	-DMATELOCALEDIR="\"$(datadir)/locale\""			\
 	-DGTK_ENGINE_DIR="\"$(GTK_ENGINE_DIR)\"" 			\

--- a/capplets/default-applications/Makefile.am
+++ b/capplets/default-applications/Makefile.am
@@ -19,7 +19,7 @@ desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 pkgconfigdir = $(datadir)/pkgconfig
 pkgconfig_DATA = mate-default-applications.pc
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(DEFAULT_APPLICATIONS_CAPPLET_CFLAGS) \
 	-DMATELOCALEDIR=\""$(datadir)/locale"\"\

--- a/capplets/display/Makefile.am
+++ b/capplets/display/Makefile.am
@@ -51,7 +51,7 @@ desktopdir = $(datadir)/applications
 Desktop_in_files = display-properties.desktop.in
 desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 
-INCLUDES   = $(DISPLAY_CAPPLET_CFLAGS) \
+AM_CPPFLAGS   = $(DISPLAY_CAPPLET_CFLAGS) \
              $(MATECC_CAPPLETS_CFLAGS) \
 	     -DSBINDIR="\"$(sbindir)\"" \
 	     -DUIDIR="\"$(uidir)\"" \

--- a/capplets/keybindings/Makefile.am
+++ b/capplets/keybindings/Makefile.am
@@ -29,7 +29,7 @@ xml_DATA = $(xml_in_files:.xml.in=.xml)
 pkgconfigdir = $(datadir)/pkgconfig
 pkgconfig_DATA = mate-keybindings.pc
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	-DMATELOCALEDIR="\"$(datadir)/locale\"" \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\"" \

--- a/capplets/keyboard/Makefile.am
+++ b/capplets/keyboard/Makefile.am
@@ -30,7 +30,7 @@ desktopdir = $(datadir)/applications
 Desktop_in_files = keyboard.desktop.in
 desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(LIBMATEKBDUI_CFLAGS) \
 	-DMATELOCALEDIR="\"$(datadir)/locale\"" \

--- a/capplets/mouse/Makefile.am
+++ b/capplets/mouse/Makefile.am
@@ -22,7 +22,7 @@ desktopdir = $(datadir)/applications
 Desktop_in_files = mate-settings-mouse.desktop.in
 desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	-DMATELOCALEDIR="\"$(datadir)/locale\"" \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\"" \

--- a/capplets/network/Makefile.am
+++ b/capplets/network/Makefile.am
@@ -28,7 +28,7 @@ desktopdir = $(datadir)/applications
 desktop_in_files = mate-network-properties.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	-DMATELOCALEDIR="\"$(datadir)/locale\"" \
 	-DMATECC_UI_DIR="\"$(uidir)\""

--- a/capplets/windows/Makefile.am
+++ b/capplets/windows/Makefile.am
@@ -18,7 +18,7 @@ desktopdir = $(datadir)/applications
 Desktop_in_files = window-properties.desktop.in
 desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 
-INCLUDES   = $(MATECC_CAPPLETS_CFLAGS)					\
+AM_CPPFLAGS   = $(MATECC_CAPPLETS_CFLAGS)					\
 	     -I$(top_srcdir)/libwindow-settings \
 	     -DMATE_WINDOW_MANAGER_MODULE_PATH=\""$(libdir)/window-manager-settings"\" \
 	     -DUIDIR=\""$(uidir)"\"  	\

--- a/font-viewer/Makefile.am
+++ b/font-viewer/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = $(FONT_VIEWER_CFLAGS) $(MATECC_CAPPLETS_CFLAGS) -DDIRECTORY_DIR=\"$(directorydir)\" \
+AM_CPPFLAGS = $(FONT_VIEWER_CFLAGS) $(MATECC_CAPPLETS_CFLAGS) -DDIRECTORY_DIR=\"$(directorydir)\" \
   -DMATELOCALEDIR=\"$(datadir)/locale\"
 
 bin_PROGRAMS = mate-thumbnail-font mate-font-viewer

--- a/libslab/Makefile.am
+++ b/libslab/Makefile.am
@@ -1,7 +1,7 @@
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libslab.pc
 
-INCLUDES =					\
+AM_CPPFLAGS =					\
 	-I$(top_srcdir)				\
 	$(LIBSLAB_CFLAGS)			\
 	$(WARN_CFLAGS)

--- a/libwindow-settings/Makefile.am
+++ b/libwindow-settings/Makefile.am
@@ -1,6 +1,6 @@
 WM_MODULE_DIR=$(libdir)/window-manager-settings
 
-INCLUDES = 								\
+AM_CPPFLAGS = 								\
 	-DMATELOCALEDIR="\"$(datadir)/locale\""			\
 	-DMATE_ICONDIR=\""$(datadir)/pixmaps"\"			\
 	-DG_LOG_DOMAIN=\"capplet-common\"				\


### PR DESCRIPTION
I leave one INCLUDES in mate-control-center/shell/Makefile.am because build fails if i change it.
