### PR TITLE
using mate-default-applications-properties.desktop im gsettings schema

### DIFF
--- a/org.mate.control-center.gschema.xml.in.in
+++ b/org.mate.control-center.gschema.xml.in.in
@@ -2,7 +2,7 @@
     <schema id="org.mate.control-center" path="/org/mate/control-center/">
         <child name="appearance" schema="org.mate.control-center.appearance" />
         <key name="cc-actions-list" type="as">
-            <_default l10n="messages">[ 'Change Theme;mate-appearance-properties.desktop', 'Set Preferred Applications;default-applications.desktop' ]</_default>
+            <_default l10n="messages">[ 'Change Theme;mate-appearance-properties.desktop', 'Set Preferred Applications;mate-default-applications-properties.desktop' ]</_default>
             <_summary>Task names and associated .desktop files</_summary>
             <_description>The task name to be displayed in the control-center followed by a ";" separator then the filename of an associated .desktop file to launch for that task.</_description>
         </key>


### PR DESCRIPTION
to avoid those warning.
*\* (mate-control-center:25359): WARNING **: get_actions_list() - PROBLEM - Can't load default-applications.desktop
