### PR TITLE
default applications: fix capplet name

### DIFF
--- a/capplets/default-applications/Makefile.am
+++ b/capplets/default-applications/Makefile.am
@@ -1,5 +1,5 @@
 # This is used in MATECC_CAPPLETS_CFLAGS
-cappletname = default-applications
+cappletname = mate-default-applications-properties
 
 bin_PROGRAMS = mate-default-applications-properties
 


### PR DESCRIPTION
to avoid this warning.
[rave@mother /]$ mate-control-center

*\* (mate-control-center:31294): WARNING **: get_actions_list() - PROBLEM - Can't load default-applications.desktop
