### PR TITLE
Fixing broken gnome.org links

### DIFF
--- a/org.mate.control-center.gschema.xml.in.in
+++ b/org.mate.control-center.gschema.xml.in.in
@@ -34,12 +34,12 @@
     </schema>
     <schema id="org.mate.control-center.appearance" path="/org/mate/control-center/appearance/">
         <key name="more-backgrounds-url" type="s">
-            <default>'http://art.gnome.org/backgrounds/'</default>
+            <default>'http://gnome-look.org/'</default>
             <_summary>More backgrounds URL</_summary>
             <_description>URL for where to get more desktop backgrounds.  If set to an empty string the link will not appear.</_description>
         </key>
         <key name="more-themes-url" type="s">
-            <default>'http://art.gnome.org/themes/'</default>
+            <default>'http://gnome-look.org/'</default>
             <_summary>More themes URL</_summary>
             <_description>URL for where to get more desktop themes.  If set to an empty string the link will not appear.</_description>
         </key>


### PR DESCRIPTION
With this commit i am fixing ticket #85. It refers to links
on gnome.org with do not longer exists.
