### PR TITLE
Change background and themes links to point to mate-desktop.org. 

### DIFF
--- a/org.mate.control-center.gschema.xml.in.in
+++ b/org.mate.control-center.gschema.xml.in.in
@@ -34,12 +34,12 @@
     </schema>
     <schema id="org.mate.control-center.appearance" path="/org/mate/control-center/appearance/">
         <key name="more-backgrounds-url" type="s">
-            <default>'http://art.gnome.org/backgrounds/'</default>
+            <default>'http://mate-desktop.org/backgrounds/'</default>
             <_summary>More backgrounds URL</_summary>
             <_description>URL for where to get more desktop backgrounds.  If set to an empty string the link will not appear.</_description>
         </key>
         <key name="more-themes-url" type="s">
-            <default>'http://art.gnome.org/themes/'</default>
+            <default>'http://mate-desktop.org/themes/'</default>
             <_summary>More themes URL</_summary>
             <_description>URL for where to get more desktop themes.  If set to an empty string the link will not appear.</_description>
         </key>


### PR DESCRIPTION
Hi,

As discussed in IRC I've created some landing pages on mate-desktop.org for Backgrounds and Themes.
- [Backgrounds](http://mate-desktop.org/backgrounds)
- [Themes](http://mate-desktop.org/themes)

This pull request simply changes the broken links pointing to art.gnome.org with links to the above landing pages. Fixes #85 and #87.
