### PR TITLE
Changed left window button layout to usual layout

### DIFF
--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -54,7 +54,7 @@
 #define MARCO_BUTTON_LAYOUT_KEY "button-layout"
 
 #define MARCO_BUTTON_LAYOUT_RIGHT "menu:minimize,maximize,close"
-#define MARCO_BUTTON_LAYOUT_LEFT "close,maximize,minimize:menu"
+#define MARCO_BUTTON_LAYOUT_LEFT "close,minimize,maximize:"
 
 /* keep following enums in sync with marco */
 enum


### PR DESCRIPTION
Most (if not all) DEs that have their window button on the left use the order close, minimise, maximise and no menu. This pull request brings MATE in line with that standard layout.
