### PR TITLE
fix for glib2-2.41.2

### DIFF
--- a/capplets/mouse/mate-mouse-properties.ui
+++ b/capplets/mouse/mate-mouse-properties.ui
@@ -288,7 +288,6 @@
                                   <object class="GtkHScale" id="accel_scale">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="update_policy">discontinuous</property>
                                     <property name="adjustment">adjustment1</property>
                                     <property name="draw_value">False</property>
                                     <property name="value_pos">right</property>
@@ -344,7 +343,6 @@
                                   <object class="GtkHScale" id="sensitivity_scale">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="update_policy">discontinuous</property>
                                     <property name="adjustment">adjustment2</property>
                                     <property name="digits">0</property>
                                     <property name="draw_value">False</property>
@@ -465,7 +463,6 @@
                                       <object class="GtkHScale" id="drag_threshold_scale">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                        <property name="update_policy">discontinuous</property>
                                         <property name="adjustment">adjustment3</property>
                                         <property name="digits">0</property>
                                         <property name="draw_value">False</property>
@@ -595,7 +592,6 @@
                                       <object class="GtkHScale" id="delay_scale">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                        <property name="update_policy">discontinuous</property>
                                         <property name="adjustment">adjustment4</property>
                                         <property name="draw_value">False</property>
                                         <accessibility>


### PR DESCRIPTION
otherwise mate-mouse-properties doesn't start anymore
taken from https://git.gnome.org/browse/gnome-control-center/commit/?id=8251128055c28a8054f41d050ea0a0266a96b72a
