### PR TITLE
GTK3: add missing style class view to AppResizer

### DIFF
--- a/libslab/app-resizer.c
+++ b/libslab/app-resizer.c
@@ -48,6 +48,10 @@ app_resizer_class_init (AppResizerClass * klass)
 static void
 app_resizer_init (AppResizer * window)
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (window)),
+                                 GTK_STYLE_CLASS_VIEW);
+#endif
 }
 
 void


### PR DESCRIPTION
this fixes https://github.com/mate-desktop/mate-control-center/issues/142