### PR TITLE
Put mate-keybindings into the correct categories.

### DIFF
--- a/capplets/keybindings/mate-keybinding.desktop.in.in
+++ b/capplets/keybindings/mate-keybinding.desktop.in.in
@@ -6,6 +6,6 @@ Icon=preferences-desktop-keyboard-shortcuts
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GTK;Settings;
+Categories=GTK;Settings;HardwareSettings;
 Keywords=mate-control-center;MATE;assign;keyboard;shortcuts;keybindings;
 OnlyShowIn=MATE;

--- a/capplets/network/mate-network-properties.desktop.in.in
+++ b/capplets/network/mate-network-properties.desktop.in.in
@@ -6,6 +6,6 @@ Icon=mate-network-properties
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GTK;Settings;
+Categories=GTK;Settings;X-MATE-NetworkSettings;
 Keywords=mate-control-center;MATE;network;http;socks;proxy;
 OnlyShowIn=MATE;


### PR DESCRIPTION
Minor tweak to put `mate-keybindings` in to the correct categories.