### PR TITLE
UI GTK3: fix keyboard and mouse properties windows

### DIFF
--- a/capplets/keyboard/mate-keyboard-properties-layout-chooser.ui
+++ b/capplets/keyboard/mate-keyboard-properties-layout-chooser.ui
@@ -6,7 +6,7 @@
     <property name="visible">True</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Choose a Layout</property>
-    <property name="default_width">670</property>
+    <property name="default_width">900</property>
     <property name="default_height">350</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
@@ -27,9 +27,9 @@
                 <child>
                   <object class="GtkAlignment" id="alignment1">
                     <property name="visible">True</property>
-                    <property name="top_padding">3</property>
-                    <property name="bottom_padding">3</property>
-                    <property name="left_padding">3</property>
+                    <property name="top_padding">6</property>
+                    <property name="bottom_padding">6</property>
+                    <property name="left_padding">10</property>
                     <property name="right_padding">6</property>
                     <child>
                       <object class="GtkTable" id="table1">
@@ -107,10 +107,10 @@
                 <child>
                   <object class="GtkAlignment" id="alignment2">
                     <property name="visible">True</property>
-                    <property name="top_padding">3</property>
-                    <property name="bottom_padding">3</property>
-                    <property name="left_padding">3</property>
-                    <property name="right_padding">3</property>
+                    <property name="top_padding">6</property>
+                    <property name="bottom_padding">6</property>
+                    <property name="left_padding">10</property>
+                    <property name="right_padding">6</property>
                     <child>
                       <object class="GtkTable" id="table3">
                         <property name="visible">True</property>
@@ -200,6 +200,8 @@
                 <property name="visible">True</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
+                <property name="width_request">900</property>
+                <property name="height_request">400</property>
                 <child>
                   <object class="GtkHBox" id="hbox1">
                     <property name="visible">True</property>

--- a/capplets/keyboard/mate-keyboard-properties-model-chooser.ui
+++ b/capplets/keyboard/mate-keyboard-properties-model-chooser.ui
@@ -8,7 +8,7 @@
     <property name="title" translatable="yes">Choose a Keyboard Model</property>
     <property name="modal">True</property>
     <property name="default_width">450</property>
-    <property name="default_height">400</property>
+    <property name="default_height">380</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="dialog-vbox2">
@@ -40,6 +40,7 @@
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">automatic</property>
                 <property name="vscrollbar_policy">automatic</property>
+                <property name="height_request">130</property>
                 <property name="shadow_type">in</property>
                 <child>
                   <object class="GtkTreeView" id="vendors_list">
@@ -70,9 +71,10 @@
               <object class="GtkScrolledWindow" id="scrolledwindow3">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
+                <property name="hscrollbar_policy">never</property>
                 <property name="vscrollbar_policy">automatic</property>
                 <property name="shadow_type">in</property>
+                <property name="height_request">130</property>
                 <child>
                   <object class="GtkTreeView" id="models_list">
                     <property name="visible">True</property>

--- a/capplets/keyboard/mate-keyboard-properties-options-dialog.ui
+++ b/capplets/keyboard/mate-keyboard-properties-options-dialog.ui
@@ -24,6 +24,7 @@
             <property name="hscrollbar_policy">automatic</property>
             <property name="vscrollbar_policy">automatic</property>
             <property name="shadow_type">out</property>
+            <property name="height_request">300</property>
             <child>
               <object class="GtkViewport" id="viewport1">
                 <property name="visible">True</property>

--- a/capplets/mouse/mate-mouse-properties.ui
+++ b/capplets/mouse/mate-mouse-properties.ui
@@ -62,6 +62,8 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Mouse Preferences</property>
     <property name="type_hint">dialog</property>
+    <property name="default_width">500</property>
+    <property name="default_height">550</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>


### PR DESCRIPTION
- this fixes unusable keyboard properties window
- reduce size of mouse properties window
