### PR TITLE
Add theme changing support for metacity >= 3.16

### DIFF
--- a/capplets/appearance/appearance-support.c
+++ b/capplets/appearance/appearance-support.c
@@ -77,6 +77,7 @@ metacity_theme_apply(const gchar *theme, const gchar *font)
     {
         gchar *gsettings_cmd = NULL;
 
+        /* for metacity <= 3.12 */
         gsettings_cmd = g_strdup_printf("gsettings set org.gnome.desktop.wm.preferences theme '%s'", theme);
         g_spawn_command_line_async (gsettings_cmd, NULL);
         g_free (gsettings_cmd);
@@ -85,6 +86,10 @@ metacity_theme_apply(const gchar *theme, const gchar *font)
         g_spawn_command_line_async (gsettings_cmd, NULL);
         g_free (gsettings_cmd);
 
+        /* for metacity >= 3.16 */
+        gsettings_cmd = g_strdup_printf("gsettings set org.gnome.metacity theme '%s'", theme);
+        g_spawn_command_line_async (gsettings_cmd, NULL);
+        g_free (gsettings_cmd);
     }
 }
 


### PR DESCRIPTION
A new compiz just landed in Ubuntu 15.10 which pretty much broke the MATE integration. Since metacity 3.1.6 the `theme` setting in `org.gnome.desktop.wm.preferences` is deprecated and ignored. 

Metacity >=3.16 now reads the `theme` from `org.gnome.metacity` although some other configuration is still accessed from `org.gnome.desktop.wm.preferences`

The pull request write the `theme` to `org.gnome.metacity` as well as the legacy location.