### PR TITLE
appearance-font: Use pango and cairo to rander fonts

### DIFF
--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -162,8 +162,8 @@ static void setup_font_sample(GtkWidget* darea, Antialiasing antialiasing, Hinti
 	pango_layout_set_markup (layout, str, -1);
 
 	pango_layout_get_extents (layout, NULL, &extents);
-	width = PANGO_PIXELS(extents.width);
-	height = PANGO_PIXELS(extents.height);
+	width = PANGO_PIXELS(extents.width) + 4;
+	height = PANGO_PIXELS(extents.height) + 2;
 
 	surface = cairo_image_surface_create (CAIRO_FORMAT_A8, width, height);
 	cr = cairo_create (surface);

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -186,6 +186,7 @@ static void setup_font_sample(GtkWidget* darea, Antialiasing antialiasing, Hinti
 	surface = cairo_image_surface_create (CAIRO_FORMAT_A8, width, height);
 	cr = cairo_create (surface);
 
+	cairo_move_to (cr, 2, 1);
 	pango_cairo_show_layout (cr, layout);
 	g_object_unref (layout);
 	cairo_destroy (cr);

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -117,18 +117,36 @@ static void set_fontoptions(PangoContext *context, Antialiasing antialiasing, Hi
 	cairo_hint_style_t hs;
 	
 	switch (antialiasing) {
-		case ANTIALIAS_NONE:			aa = CAIRO_ANTIALIAS_NONE; break;
-		case ANTIALIAS_GRAYSCALE:		aa = CAIRO_ANTIALIAS_GRAY; break;
-		case ANTIALIAS_RGBA:			aa = CAIRO_ANTIALIAS_SUBPIXEL; break;
-		default:						aa = CAIRO_ANTIALIAS_DEFAULT; break;
+	case ANTIALIAS_NONE:
+		aa = CAIRO_ANTIALIAS_NONE;
+		break;
+	case ANTIALIAS_GRAYSCALE:
+		aa = CAIRO_ANTIALIAS_GRAY;
+		break;
+	case ANTIALIAS_RGBA:
+		aa = CAIRO_ANTIALIAS_SUBPIXEL;
+		break;
+	default:
+		aa = CAIRO_ANTIALIAS_DEFAULT;
+		break;
 	}
 
 	switch (hinting) {
-		case HINT_NONE:					hs = CAIRO_HINT_STYLE_NONE; break;
-		case HINT_SLIGHT:				hs = CAIRO_HINT_STYLE_SLIGHT; break;
-		case HINT_MEDIUM:				hs = CAIRO_HINT_STYLE_MEDIUM; break;
-		case HINT_FULL:					hs = CAIRO_HINT_STYLE_FULL; break;
-		default:						hs = CAIRO_HINT_STYLE_DEFAULT; break;
+	case HINT_NONE:
+		hs = CAIRO_HINT_STYLE_NONE;
+		break;
+	case HINT_SLIGHT:
+		hs = CAIRO_HINT_STYLE_SLIGHT;
+		break;
+	case HINT_MEDIUM:
+		hs = CAIRO_HINT_STYLE_MEDIUM;
+		break;
+	case HINT_FULL:
+		hs = CAIRO_HINT_STYLE_FULL;
+		break;
+	default:
+		hs = CAIRO_HINT_STYLE_DEFAULT;
+		break;
 	}
 
 	opt = cairo_font_options_create ();

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -53,18 +53,12 @@ static void sample_expose(GtkWidget* darea, GdkEventExpose* expose)
 #endif
 {
 	cairo_surface_t* surface = g_object_get_data(G_OBJECT(darea), "sample-surface");
-
+	GtkAllocation allocation;
 	int x, y, w, h;
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-	x = gtk_widget_get_allocated_width (darea);
-	y = gtk_widget_get_allocated_height (darea);
-#else
-	GtkAllocation allocation;
 	gtk_widget_get_allocation (darea, &allocation);
 	x = allocation.width;
 	y = allocation.height;
-#endif
 	w = cairo_image_surface_get_width (surface);
 	h = cairo_image_surface_get_height (surface);
 


### PR DESCRIPTION
This patch fixes #135, and the boxes do not get smaller.