### PR TITLE
Restore Interface tab in Appearance capplet

### DIFF
--- a/capplets/appearance/Makefile.am
+++ b/capplets/appearance/Makefile.am
@@ -16,6 +16,8 @@ mate_appearance_properties_SOURCES = \
 	appearance-themes.h \
 	appearance-style.c \
 	appearance-style.h \
+	appearance-ui.c \
+	appearance-ui.h \
 	appearance-support.c \
 	appearance-support.h \
 	mate-wp-info.c \

--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -25,6 +25,7 @@
 #include "appearance-font.h"
 #include "appearance-themes.h"
 #include "appearance-style.h"
+#include "appearance-ui.h"
 #include "appearance-support.h"
 #include "theme-installer.h"
 #include "theme-thumbnail.h"
@@ -188,6 +189,7 @@ main (int argc, char **argv)
   desktop_init (data, (const gchar **) wallpaper_files);
   g_strfreev (wallpaper_files);
   font_init (data);
+  ui_init (data);
 
   /* init support for other window managers */
   support_init (data);

--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -33,11 +33,11 @@ show_handlebar (AppearanceData *data, gboolean show)
   g_object_ref (handlebox);
   g_object_ref (toolbar);
 
-  if (GTK_BIN (align)->child)
-    gtk_container_remove (GTK_CONTAINER (align), GTK_BIN (align)->child);
+  if (gtk_bin_get_child (GTK_BIN (align)))
+    gtk_container_remove (GTK_CONTAINER (align), gtk_bin_get_child (GTK_BIN (align)));
 
-  if (GTK_BIN (handlebox)->child)
-    gtk_container_remove (GTK_CONTAINER (handlebox), GTK_BIN (handlebox)->child);
+  if (gtk_bin_get_child (GTK_BIN (handlebox)))
+    gtk_container_remove (GTK_CONTAINER (handlebox), gtk_bin_get_child (GTK_BIN (handlebox)));
 
   if (show) {
     gtk_container_add (GTK_CONTAINER (align), handlebox);

--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2007 The GNOME Foundation
+ * Written by Jonathan Blandford <jrb@gnome.org>
+ *            Jens Granseuer <jensgr@gmx.net>
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "appearance.h"
+#include "stdio.h"
+
+
+static void
+show_handlebar (AppearanceData *data, gboolean show)
+{
+  GtkWidget *handlebox = appearance_capplet_get_widget (data, "toolbar_handlebox");
+  GtkWidget *toolbar = appearance_capplet_get_widget (data, "toolbar_toolbar");
+  GtkWidget *align = appearance_capplet_get_widget (data, "toolbar_align");
+
+  g_object_ref (handlebox);
+  g_object_ref (toolbar);
+
+  if (GTK_BIN (align)->child)
+    gtk_container_remove (GTK_CONTAINER (align), GTK_BIN (align)->child);
+
+  if (GTK_BIN (handlebox)->child)
+    gtk_container_remove (GTK_CONTAINER (handlebox), GTK_BIN (handlebox)->child);
+
+  if (show) {
+    gtk_container_add (GTK_CONTAINER (align), handlebox);
+    gtk_container_add (GTK_CONTAINER (handlebox), toolbar);
+    g_object_unref (handlebox);
+  } else {
+    gtk_container_add (GTK_CONTAINER (align), toolbar);
+  }
+
+  g_object_unref (toolbar);
+}
+
+static void
+set_toolbar_style (AppearanceData *data, const char *value)
+{
+  static const GtkToolbarStyle gtk_toolbar_styles[] =
+    { GTK_TOOLBAR_BOTH, GTK_TOOLBAR_BOTH_HORIZ, GTK_TOOLBAR_ICONS, GTK_TOOLBAR_TEXT };
+
+  int enum_val = gtk_combo_box_get_active((GtkComboBox *)
+			 appearance_capplet_get_widget (data, "toolbar_style_select"));
+
+  gtk_toolbar_set_style (GTK_TOOLBAR (appearance_capplet_get_widget (data, "toolbar_toolbar")),
+			 gtk_toolbar_styles[enum_val]);
+}
+
+static void
+set_have_icons (AppearanceData *data, gboolean value)
+{
+  static const char *menu_item_names[] = {
+    "menu_item_1",
+    "menu_item_2",
+    "menu_item_3",
+    "menu_item_4",
+    "menu_item_5",
+    "cut",
+    "copy",
+    "paste",
+    NULL
+  };
+
+  const char **name;
+
+  for (name = menu_item_names; *name != NULL; name++) {
+    GtkImageMenuItem *item = GTK_IMAGE_MENU_ITEM (appearance_capplet_get_widget (data, *name));
+    GtkWidget *image;
+
+    if (value) {
+      image = g_object_get_data (G_OBJECT (item), "image");
+      if (image) {
+	gtk_image_menu_item_set_image (item, image);
+	g_object_unref (image);
+      }
+    } else {
+      image = gtk_image_menu_item_get_image (item);
+      g_object_set_data (G_OBJECT (item), "image", image);
+      g_object_ref (image);
+      gtk_image_menu_item_set_image (item, NULL);
+    }
+  }
+}
+
+/** GConf Callbacks and Conversions **/
+
+static gboolean
+toolbar_to_widget (GValue *value, GVariant *variant, gpointer user_data)
+{
+  const gchar *val = g_variant_get_string(variant, NULL);
+  gint i = 0;
+
+  if (g_strcmp0(val, "both-horiz") == 0 || g_strcmp0(val, "both_horiz") == 0)
+    i = 1;
+  else if (g_strcmp0(val, "icons") == 0)
+    i = 2;
+  else if (g_strcmp0(val, "text") == 0)
+    i = 3;
+
+  g_value_set_int(value, i);
+
+  return TRUE;
+}
+
+static GVariant *
+toolbar_from_widget (const GValue *value,
+			  const GVariantType *expected_type,
+			  gpointer user_data)
+{
+  static const char *gtk_toolbar_styles_str[] = {
+    "both", "both-horiz", "icons", "text" };
+
+  gint index = g_value_get_int(value);
+  return g_variant_new_string(gtk_toolbar_styles_str[index]);
+}
+
+static void
+toolbar_style_cb (GSettings *settings,
+		     gchar *key,
+		     AppearanceData      *data)
+{
+  set_toolbar_style (data, g_settings_get_string (settings, key));
+}
+
+static void
+menus_have_icons_cb (GSettings *settings,
+		     gchar *key,
+		     AppearanceData      *data)
+{
+  set_have_icons (data, g_settings_get_boolean (settings, key));
+}
+
+static void
+toolbar_detachable_cb (GSettings *settings,
+		     gchar *key,
+		     AppearanceData *data)
+{
+  show_handlebar (data, g_settings_get_boolean (settings, key));
+}
+
+/** GUI Callbacks **/
+
+static gint
+button_press_block_cb (GtkWidget *toolbar,
+		       GdkEvent  *event,
+		       gpointer   data)
+{
+  return TRUE;
+}
+
+/** Public Functions **/
+
+void
+ui_init (AppearanceData *data)
+{
+  GtkWidget* widget;
+  char* toolbar_style;
+
+  widget = appearance_capplet_get_widget(data, "menu_accel_toggle");
+	g_settings_bind (data->interface_settings,
+			 ACCEL_CHANGE_KEY,
+			 G_OBJECT (widget),
+			 "active",
+			 G_SETTINGS_BIND_DEFAULT);
+
+  widget = appearance_capplet_get_widget(data, "menu_icons_toggle");
+	g_settings_bind (data->interface_settings,
+			 MENU_ICONS_KEY,
+			 G_OBJECT (widget),
+			 "active",
+			 G_SETTINGS_BIND_DEFAULT);
+  g_signal_connect (data->interface_settings, "changed::" MENU_ICONS_KEY,
+                      G_CALLBACK (menus_have_icons_cb), data);
+
+  set_have_icons (data,
+    g_settings_get_boolean (data->interface_settings,
+			   MENU_ICONS_KEY));
+
+  widget = appearance_capplet_get_widget(data, "toolbar_style_select");
+	g_settings_bind_with_mapping (data->interface_settings,
+			 TOOLBAR_STYLE_KEY,
+			 G_OBJECT (widget),
+			 "active",
+			 G_SETTINGS_BIND_DEFAULT,
+			 toolbar_to_widget,
+			 toolbar_from_widget,
+			 data,
+			 NULL);
+
+  g_signal_connect (data->interface_settings, "changed::" TOOLBAR_STYLE_KEY,
+		    (GCallback) toolbar_style_cb, data);
+
+  g_signal_connect (appearance_capplet_get_widget (data, "toolbar_handlebox"),
+		    "button_press_event",
+		    (GCallback) button_press_block_cb, NULL);
+
+  show_handlebar (data,
+    g_settings_get_boolean (data->interface_settings,
+			   TOOLBAR_DETACHABLE_KEY));
+
+  toolbar_style = g_settings_get_string
+    (data->interface_settings,
+     TOOLBAR_STYLE_KEY);
+  set_toolbar_style (data, toolbar_style);
+  g_free (toolbar_style);
+
+  /* no ui for detachable toolbars */
+  g_signal_connect (data->interface_settings,
+			   "changed::" TOOLBAR_DETACHABLE_KEY, (GCallback) toolbar_detachable_cb, data);
+}

--- a/capplets/appearance/appearance-ui.h
+++ b/capplets/appearance/appearance-ui.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2007 The GNOME Foundation
+ * Written by Jens Granseuer <jensgr@gmx.net>
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+void ui_init (AppearanceData *data);

--- a/capplets/appearance/appearance.h
+++ b/capplets/appearance/appearance.h
@@ -45,6 +45,10 @@
 #define GTK_THEME_KEY                "gtk-theme"
 #define ICON_THEME_KEY               "icon-theme"
 #define COLOR_SCHEME_KEY             "gtk-color-scheme"
+#define ACCEL_CHANGE_KEY             "can-change-accels"
+#define MENU_ICONS_KEY               "menus-have-icons"
+#define TOOLBAR_DETACHABLE_KEY       "toolbar-detachable"
+#define TOOLBAR_STYLE_KEY            "toolbar-style"
 #define GTK_FONT_DEFAULT_VALUE       "Sans 10"
 
 #define LOCKDOWN_SCHEMA              "org.mate.lockdown"

--- a/capplets/appearance/data/appearance.ui
+++ b/capplets/appearance/data/appearance.ui
@@ -1549,6 +1549,370 @@
                 <property name="tab_fill">False</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkVBox" id="interface_vbox">
+                <property name="visible">True</property>
+                <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">18</property>
+                <child>
+                  <object class="GtkVBox" id="vbox23">
+                    <property name="visible">True</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label35">
+                        <property name="visible">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Menus and Toolbars</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkHBox" id="hbox10">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel" id="label36">
+                            <property name="visible">True</property>
+                            <property name="label">    </property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkVBox" id="vbox24">
+                            <property name="visible">True</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkCheckButton" id="menu_icons_toggle">
+                                <property name="label" translatable="yes">Show _icons in menus</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="active">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="menu_accel_toggle">
+                                <property name="label" translatable="yes">_Editable menu shortcut keys</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkHBox" id="hbox11">
+                                <property name="visible">True</property>
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkLabel" id="label37">
+                                    <property name="visible">True</property>
+                                    <property name="label" translatable="yes">Toolbar _button labels:</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="justify">center</property>
+                                    <property name="mnemonic_widget">toolbar_style_select</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBox" id="toolbar_style_select">
+                                    <property name="visible">True</property>
+                                    <property name="model">toolbar_style_liststore</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext3"/>
+                                      <attributes>
+                                        <attribute name="text">0</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkVBox" id="vbox25">
+                    <property name="visible">True</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label38">
+                        <property name="visible">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Preview</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkHBox" id="hbox12">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel" id="label39">
+                            <property name="visible">True</property>
+                            <property name="label">    </property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkVBox" id="vbox26">
+                            <property name="visible">True</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkMenuBar" id="menubar">
+                                <property name="visible">True</property>
+                                <child>
+                                  <object class="GtkMenuItem" id="File Menu">
+                                    <property name="visible">True</property>
+                                    <property name="label" translatable="yes">_File</property>
+                                    <property name="use_underline">True</property>
+                                    <child type="submenu">
+                                      <object class="GtkMenu" id="File Menu_menu">
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="menu_item_1">
+                                            <property name="label">gtk-new</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use-stock">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="menu_item_2">
+                                            <property name="label">gtk-open</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="menu_item_3">
+                                            <property name="label">gtk-save</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkMenuItem" id="separator1">
+                                            <property name="visible">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="menu_item_4">
+                                            <property name="label">gtk-print</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkMenuItem" id="separator2">
+                                            <property name="visible">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="menu_item_5">
+                                            <property name="label">gtk-quit</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkMenuItem" id="edit">
+                                    <property name="visible">True</property>
+                                    <property name="label" translatable="yes">Edit</property>
+                                    <property name="use_underline">True</property>
+                                    <child type="submenu">
+                                      <object class="GtkMenu" id="edit1_menu">
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="cut">
+                                            <property name="label">gtk-cut</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="copy">
+                                            <property name="label">gtk-copy</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImageMenuItem" id="paste">
+                                            <property name="label">gtk-paste</property>
+                                            <property name="visible">True</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="use_stock">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="toolbar_align">
+                                <property name="visible">True</property>
+                                <child>
+                                  <object class="GtkHandleBox" id="toolbar_handlebox">
+                                    <property name="visible">True</property>
+                                    <child>
+                                      <object class="GtkToolbar" id="toolbar_toolbar">
+                                        <property name="visible">True</property>
+                                        <property name="toolbar_style">both</property>
+                                        <child>
+                                          <object class="GtkToolButton" id="button2">
+                                            <property name="visible">True</property>
+                                            <property name="is_important">True</property>
+                                            <property name="stock_id">gtk-new</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkToolButton" id="button4">
+                                            <property name="visible">True</property>
+                                            <property name="stock_id">gtk-open</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkToolButton" id="save_button">
+                                            <property name="visible">True</property>
+                                            <property name="stock_id">gtk-save</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="label40">
+                <property name="visible">True</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="label" translatable="yes">Interface</property>
+              </object>
+              <packing>
+                <property name="position">3</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="position">1</property>

--- a/capplets/appearance/data/appearance.ui
+++ b/capplets/appearance/data/appearance.ui
@@ -1840,7 +1840,7 @@
                                     <child>
                                       <object class="GtkToolbar" id="toolbar_toolbar">
                                         <property name="visible">True</property>
-                                        <property name="toolbar_style">both</property>
+                                        <property name="toolbar_style">both-horiz</property>
                                         <child>
                                           <object class="GtkToolButton" id="button2">
                                             <property name="visible">True</property>


### PR DESCRIPTION
I found this thing pretty useful, so I decided to restore it.
As a bonus, help (mate-appearance-properties -h) still mentions the Interface tab, so this also fixes that. :)

Screenshot:
![default](https://cloud.githubusercontent.com/assets/1510457/9567893/486b0e40-4f54-11e5-8e8e-9c11029f093b.png)

Note that I only tested it with GTK2. If anyone tell me where I can find a live cd with GTK3-based MATE, I can test it there as well.