### PR TITLE
RFC: Add categorisation of Preferences menu.

### DIFF
--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -27,9 +27,9 @@ directory_DATA = $(directory_in_files:.directory.in=.directory)
 @INTLTOOL_DIRECTORY_RULE@
 
 menudir = $(sysconfdir)/xdg/menus
-menu_DATA = matecc.menu
+menu_DATA = matecc.menu mate-preferences-categories.menu
 
-EXTRA_DIST = matecc.desktop.in.in matecc.directory.in matecc.menu
+EXTRA_DIST = matecc.desktop.in.in matecc.directory.in matecc.menu mate-preferences-categories.menu
 
 DISTCLEANFILES = matecc.desktop matecc.desktop.in matecc.directory
 

--- a/shell/mate-preferences-categories.menu
+++ b/shell/mate-preferences-categories.menu
@@ -1,0 +1,114 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN"
+  "http://www.freedesktop.org/standards/menu-spec/1.0/menu.dtd">
+
+<Menu>
+  <Name>Preferences</Name>
+ 
+  <Menu>
+    <Name>Personal</Name>
+    <Directory>mate-personal.directory</Directory>
+    <Include>
+      <And>
+        <Category>Settings</Category>
+        <Category>X-MATE-PersonalSettings</Category>
+        <Not><Category>System</Category></Not>
+      </And>
+      <And>
+        <Category>Settings</Category>
+        <Category>X-GNOME-PersonalSettings</Category>
+        <Not><Category>System</Category></Not>
+      </And>
+      <And>
+        <Category>Settings</Category>
+        <Category>X-GNOME-SystemSettings</Category>
+        <Category>Archiving</Category>
+      </And>
+      <And>
+        <Category>Settings</Category>
+        <Category>Accessibility</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Look and Feel</Name>
+    <Directory>mate-look-and-feel.directory</Directory>
+    <Include>
+      <And>
+        <Category>Settings</Category>
+        <Category>DesktopSettings</Category>
+        <Not><Category>System</Category></Not>
+        <Not><Category>Security</Category></Not>
+      </And>
+      <And>
+        <Category>Settings</Category>
+        <Category>Qt</Category>
+        <Not><Category>System</Category></Not>
+        <Not><Category>Security</Category></Not>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Internet and Network</Name>
+    <Directory>mate-internet-and-network.directory</Directory>
+    <Include>
+      <And>
+        <Category>Settings</Category>
+        <Category>X-MATE-NetworkSettings</Category>
+        <Not><Category>System</Category></Not>
+      </And>
+      <And>
+        <Category>Settings</Category>
+        <Category>X-GNOME-NetworkSettings</Category>
+        <Not><Category>System</Category></Not>
+      </And>
+      <And>
+        <Category>Settings</Category>
+        <Category>Security</Category>
+        <Not><Category>System</Category></Not>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Hardware</Name>
+    <Directory>mate-hardware.directory</Directory>
+    <Include>
+      <And>
+        <Category>Settings</Category>
+        <Category>HardwareSettings</Category>
+        <Not><Category>System</Category></Not>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Other</Name>
+    <Directory>mate-other.directory</Directory>
+    <Include>
+      <And>
+        <Category>Settings</Category>
+        <Not><Category>Accessibility</Category></Not>
+        <Not><Category>System</Category></Not>
+        <Not><Category>DesktopSettings</Category></Not>
+        <Not><Category>HardwareSettings</Category></Not>
+        <Not><Category>Security</Category></Not>
+        <Not><Category>Archiving</Category></Not>
+        <Not><Category>Qt</Category></Not>
+        <Not><Category>X-MATE-NetworkSettings</Category></Not>
+        <Not><Category>X-GNOME-NetworkSettings</Category></Not>
+        <Not><Category>X-MATE-PersonalSettings</Category></Not>
+        <Not><Category>X-GNOME-PersonalSettings</Category></Not>
+      </And>
+    </Include>
+    <Exclude>
+      <Filename>matecc.desktop</Filename>
+    </Exclude>
+  </Menu>
+
+  <Exclude>
+    <Category>Settings</Category>
+  </Exclude>
+</Menu>
+


### PR DESCRIPTION
This pull request is a proposal to add categories to the Preferences menu in MATE 1.12. This has been default in Ubuntu MATE for some time now and a screen shot is included to demonstrate what this looks like.

![screenshot](https://cloud.githubusercontent.com/assets/304639/9736430/0c8b53d0-5639-11e5-9d94-6dd35395a0fe.png)

The advantage of these categories is that the menu doesn't scroll off the screen on lower resolution displays and each item appears in a single category, making it easier to locate based on category.
This has been tested on Linux Mint MATE 17.2 without issue and I believe a variation of this preferences menu is available for Fedora also.