### PR TITLE
libslab: use GtkBox instead of GtkVBox in both GTK+ builds

### DIFF
--- a/libslab/app-resizer.c
+++ b/libslab/app-resizer.c
@@ -275,13 +275,12 @@ app_resizer_size_allocate (GtkWidget * widget, GtkAllocation * allocation)
 }
 
 GtkWidget *
-app_resizer_new (GtkVBox * child, gint initial_num_columns, gboolean homogeneous,
+app_resizer_new (GtkBox * child, gint initial_num_columns, gboolean homogeneous,
 	AppShellData * app_data)
 {
 	AppResizer *widget;
 
 	g_assert (child != NULL);
-	g_assert (GTK_IS_VBOX (child));
 
 	widget = g_object_new (APP_RESIZER_TYPE, NULL);
 	widget->cached_element_width = -1;

--- a/libslab/app-resizer.h
+++ b/libslab/app-resizer.h
@@ -45,7 +45,7 @@ struct _AppResizer
 {
 	GtkLayout parent;
 
-	GtkVBox *child;
+	GtkBox *child;
 	GList *cached_tables_list;
 	gint cached_element_width;
 	gint cached_table_spacing;
@@ -64,7 +64,7 @@ void app_resizer_set_homogeneous (AppResizer * widget, gboolean value);
 void remove_container_entries (GtkContainer * widget);
 
 GType app_resizer_get_type (void);
-GtkWidget *app_resizer_new (GtkVBox * child, gint initial_num_columns, gboolean homogeneous,
+GtkWidget *app_resizer_new (GtkBox * child, gint initial_num_columns, gboolean homogeneous,
 	AppShellData * app_data);
 void app_resizer_set_table_cache (AppResizer * widget, GList * cache_list);
 void app_resizer_layout_table_default (AppResizer * widget, GtkTable * table, GList * element_list);

--- a/libslab/app-shell.c
+++ b/libslab/app-shell.c
@@ -256,7 +256,11 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 	app_data->shell = shell_window_new (app_data);
 	app_data->static_actions = actions;
 
-	right_vbox = gtk_vbox_new (FALSE, CATEGORY_SPACING);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	right_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+#else
+	right_vbox = gtk_vbox_new (FALSE, 0);
+#endif
 
 	num_cols = SIZING_SCREEN_WIDTH_LARGE_NUMCOLS;
 	if (gdk_screen_width () <= SIZING_SCREEN_WIDTH_LARGE)
@@ -267,7 +271,7 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 			num_cols = SIZING_SCREEN_WIDTH_MEDIUM_NUMCOLS;
 	}
 	app_data->category_layout =
-		app_resizer_new (GTK_VBOX (right_vbox), num_cols, TRUE, app_data);
+		app_resizer_new (GTK_BOX (right_vbox), num_cols, TRUE, app_data);
 
 	sw = gtk_scrolled_window_new (NULL, NULL);
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw), GTK_POLICY_AUTOMATIC,
@@ -285,7 +289,11 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 	gtk_container_set_focus_vadjustment (GTK_CONTAINER (right_vbox),
 		gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (sw)));
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	left_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 15);
+#else
 	left_vbox = gtk_vbox_new (FALSE, 15);
+#endif
 
 	filter_section = create_filter_section (app_data, filter_title);
 	app_data->filter_section = filter_section;
@@ -307,7 +315,7 @@ static gboolean
 relayout_shell_partial (gpointer user_data)
 {
 	AppShellData *app_data = (AppShellData *) user_data;
-	GtkVBox *vbox = APP_RESIZER (app_data->category_layout)->child;
+	GtkBox *vbox = APP_RESIZER (app_data->category_layout)->child;
 	CategoryData *data;
 
 	if (app_data->stop_incremental_relayout)
@@ -321,7 +329,7 @@ relayout_shell_partial (gpointer user_data)
 		{
 			populate_application_category_section (app_data, data->section,
 				data->filtered_launcher_list);
-			gtk_box_pack_start (GTK_BOX (vbox), GTK_WIDGET (data->section), TRUE, TRUE,
+			gtk_box_pack_start (vbox, GTK_WIDGET (data->section), TRUE, TRUE,
 				0);
 			app_data->filtered_out_everything = FALSE;
 		}
@@ -349,7 +357,7 @@ relayout_shell_partial (gpointer user_data)
 static void
 relayout_shell_incremental (AppShellData * app_data)
 {
-	GtkVBox *vbox = APP_RESIZER (app_data->category_layout)->child;
+	GtkBox *vbox = APP_RESIZER (app_data->category_layout)->child;
 
 	app_data->stop_incremental_relayout = FALSE;
 	app_data->filtered_out_everything = TRUE;
@@ -368,7 +376,7 @@ static void
 relayout_shell (AppShellData * app_data)
 {
 	GtkWidget *shell = app_data->shell;
-	GtkVBox *vbox = APP_RESIZER (app_data->category_layout)->child;
+	GtkBox *vbox = APP_RESIZER (app_data->category_layout)->child;
 
 	populate_application_category_sections (app_data, GTK_WIDGET (vbox));
 	app_resizer_set_table_cache (APP_RESIZER (app_data->category_layout),
@@ -395,7 +403,11 @@ create_actions_section (AppShellData * app_data, const gchar * title,
 	section = slab_section_new (title, Style1);
 	g_object_ref (section);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+#else
 	vbox = gtk_vbox_new (FALSE, 0);
+#endif
 	slab_section_set_contents (SLAB_SECTION (section), vbox);
 
 	if (app_data->static_actions)
@@ -438,7 +450,11 @@ create_groups_section (AppShellData * app_data, const gchar * title)
 	section = slab_section_new (title, Style1);
 	g_object_ref (section);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+#else
 	vbox = gtk_vbox_new (FALSE, 0);
+#endif
 	slab_section_set_contents (SLAB_SECTION (section), vbox);
 
 	return section;
@@ -448,13 +464,10 @@ static void
 populate_groups_section (AppShellData * app_data)
 {
 	SlabSection *section = SLAB_SECTION (app_data->groups_section);
-	GtkVBox *vbox;
+	GtkBox *vbox;
 	GList *cat_list;
 
-	/* Make sure our implementation has not changed and it's still a GtkVBox */
-	g_assert (GTK_IS_VBOX (section->contents));
-
-	vbox = GTK_VBOX (section->contents);
+	vbox = GTK_BOX (section->contents);
 	remove_container_entries (GTK_CONTAINER (vbox));
 
 	cat_list = app_data->categories_list;
@@ -464,7 +477,7 @@ populate_groups_section (AppShellData * app_data)
 		if (NULL != data->filtered_launcher_list)
 		{
 			gtk_widget_set_state (GTK_WIDGET (data->group_launcher), GTK_STATE_NORMAL);
-			gtk_box_pack_start (GTK_BOX (vbox), GTK_WIDGET (data->group_launcher),
+			gtk_box_pack_start (vbox, GTK_WIDGET (data->group_launcher),
 				FALSE, FALSE, 0);
 		}
 	}
@@ -499,8 +512,7 @@ handle_group_clicked (Tile * tile, TileEvent * event, gpointer user_data)
 		if (NULL != cat_data->filtered_launcher_list)
 		{
 			gtk_widget_get_allocation (GTK_WIDGET (cat_data->section), &allocation);
-			total += allocation.height +
-				CATEGORY_SPACING;
+			total += allocation.height;
 		}
 	}
 	while (NULL != (cat_list = g_list_next (cat_list)));
@@ -731,7 +743,11 @@ create_application_category_sections (AppShellData * app_data)
 		g_object_ref (data->section);
 		g_free (markup);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+		hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
 		hbox = gtk_hbox_new (FALSE, 0);
+#endif
 		table = gtk_table_new (0, 0, TRUE);
 		gtk_table_set_col_spacings (GTK_TABLE (table), 5);
 		gtk_table_set_row_spacings (GTK_TABLE (table), 5);
@@ -757,7 +773,11 @@ show_no_results_message (AppShellData * app_data, GtkWidget * containing_vbox)
 		app_data->filtered_out_everything_widget = gtk_alignment_new (0.5, 0.5, 0.0, 0.0);
 		g_object_ref (app_data->filtered_out_everything_widget);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+		hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
 		hbox = gtk_hbox_new (FALSE, 0);
+#endif
 		image = themed_icon_new ("face-surprise", GTK_ICON_SIZE_DIALOG);
 		gtk_box_pack_start (GTK_BOX (hbox), image, FALSE, FALSE, 0);
 
@@ -818,7 +838,6 @@ populate_application_category_section (AppShellData * app_data, SlabSection * se
 	GtkTable *table;
 	GList *children;
 
-	g_assert (GTK_IS_HBOX (section->contents));
 	hbox = GTK_WIDGET (section->contents);
 
 	children = gtk_container_get_children (GTK_CONTAINER (hbox));

--- a/libslab/app-shell.h
+++ b/libslab/app-shell.h
@@ -35,7 +35,6 @@
 extern "C" {
 #endif
 
-#define CATEGORY_SPACING 0
 #define GROUP_POSITION_NUMBER_KEY "Unique Group Position Number"
 #define APP_ACTION_KEY  "Unique Application Action Key"
 

--- a/libslab/nameplate-tile.c
+++ b/libslab/nameplate-tile.c
@@ -232,8 +232,13 @@ nameplate_tile_setup (NameplateTile *this)
 	priv->header_ctnr = GTK_CONTAINER (gtk_alignment_new (0.0, 0.5, 1.0, 1.0));
 	priv->subheader_ctnr = GTK_CONTAINER (gtk_alignment_new (0.0, 0.5, 1.0, 1.0));
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+#else
 	hbox = gtk_hbox_new (FALSE, 6);
 	vbox = gtk_vbox_new (FALSE, 0);
+#endif
 
 	alignment = gtk_alignment_new (0.0, 0.5, 1.0, 0.0);
 

--- a/libslab/search-bar.c
+++ b/libslab/search-bar.c
@@ -57,7 +57,7 @@ enum
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-G_DEFINE_TYPE (NldSearchBar, nld_search_bar, GTK_TYPE_VBOX)
+G_DEFINE_TYPE (NldSearchBar, nld_search_bar, GTK_TYPE_BOX)
 
 static void emit_search (NldSearchBar * search_bar);
 static void emit_search_callback (GtkWidget * widget, gpointer search_bar);
@@ -88,8 +88,13 @@ nld_search_bar_init (NldSearchBar * search_bar)
 	GtkWidget *entry;
 
 	gtk_widget_set_can_focus (GTK_WIDGET (search_bar), TRUE);
+	gtk_orientable_set_orientation (GTK_ORIENTABLE (search_bar), GTK_ORIENTATION_VERTICAL);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	priv->hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 3);
+#else
 	priv->hbox = gtk_hbox_new (FALSE, 3);
+#endif
 	gtk_box_pack_start (GTK_BOX (search_bar), priv->hbox, TRUE, FALSE, 0);
 
 	alignment = gtk_alignment_new (0.0, 0.5, 1.0, 0.0);

--- a/libslab/search-bar.h
+++ b/libslab/search-bar.h
@@ -36,12 +36,12 @@ extern "C" {
 
 typedef struct
 {
-	GtkVBox parent;
+	GtkBox parent;
 } NldSearchBar;
 
 typedef struct
 {
-	GtkVBoxClass parent_class;
+	GtkBoxClass parent_class;
 
 	void (*search) (NldSearchBar *, int context_id, const char *text);
 } NldSearchBarClass;

--- a/libslab/search-context-picker.c
+++ b/libslab/search-context-picker.c
@@ -67,24 +67,28 @@ static void
 nld_search_context_picker_init (NldSearchContextPicker * picker)
 {
 	NldSearchContextPickerPrivate *priv = NLD_SEARCH_CONTEXT_PICKER_GET_PRIVATE (picker);
-	GtkBox *hbox;
+	GtkWidget *hbox;
 	GtkWidget *separator;
 
-	hbox = GTK_BOX (gtk_hbox_new (FALSE, 10));
-	gtk_container_add (GTK_CONTAINER (picker), GTK_WIDGET (hbox));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 10);
+#else
+	hbox = gtk_hbox_new (FALSE, 10);
+#endif
+	gtk_container_add (GTK_CONTAINER (picker), hbox);
 
 	priv->cur_icon = GTK_IMAGE (gtk_image_new ());
-	gtk_box_pack_start (hbox, GTK_WIDGET (priv->cur_icon), FALSE, FALSE, 0);
+	gtk_box_pack_start (GTK_BOX (hbox), GTK_WIDGET (priv->cur_icon), FALSE, FALSE, 0);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 	separator = gtk_separator_new (GTK_ORIENTATION_VERTICAL);
 #else
 	separator = gtk_vseparator_new ();
 #endif
-	gtk_box_pack_start (hbox, separator, FALSE, FALSE, 0);
-	gtk_box_pack_start (hbox, gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE), FALSE, FALSE, 0);
+	gtk_box_pack_start (GTK_BOX (hbox), separator, FALSE, FALSE, 0);
+	gtk_box_pack_start (GTK_BOX (hbox), gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE), FALSE, FALSE, 0);
 
-	gtk_widget_show_all (GTK_WIDGET (hbox));
+	gtk_widget_show_all (hbox);
 
 	priv->cur_context = -1;
 

--- a/libslab/shell-window.c
+++ b/libslab/shell-window.c
@@ -60,7 +60,11 @@ shell_window_new (AppShellData * app_data)
 	gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
 	gtk_frame_set_shadow_type(GTK_FRAME(window), GTK_SHADOW_NONE);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	window->_hbox = GTK_BOX (gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0));
+#else
 	window->_hbox = GTK_BOX (gtk_hbox_new (FALSE, 0));
+#endif
 	gtk_container_add (GTK_CONTAINER (window), GTK_WIDGET (window->_hbox));
 
 #if GTK_CHECK_VERSION (3, 0, 0)

--- a/libslab/slab-section.c
+++ b/libslab/slab-section.c
@@ -20,7 +20,7 @@
 
 #include "slab-section.h"
 
-G_DEFINE_TYPE (SlabSection, slab_section, GTK_TYPE_VBOX)
+G_DEFINE_TYPE (SlabSection, slab_section, GTK_TYPE_BOX)
 
 static void slab_section_finalize (GObject *);
 
@@ -123,6 +123,7 @@ slab_section_new_with_markup (const gchar * title_markup, SlabStyle style)
 	gchar * widget_theming_name;
 
 	section = g_object_new (SLAB_SECTION_TYPE, NULL);
+	gtk_orientable_set_orientation (GTK_ORIENTABLE (section), GTK_ORIENTATION_VERTICAL);
 	gtk_box_set_homogeneous (GTK_BOX (section), FALSE);
 	gtk_box_set_spacing (GTK_BOX (section), 0);
 	section->style = style;
@@ -145,7 +146,11 @@ slab_section_new_with_markup (const gchar * title_markup, SlabStyle style)
 	}
 	gtk_box_pack_start (GTK_BOX (section), align, TRUE, TRUE, 0);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	section->childbox = GTK_BOX (gtk_box_new (GTK_ORIENTATION_VERTICAL, 10));
+#else
 	section->childbox = GTK_BOX (gtk_vbox_new (FALSE, 10));
+#endif
 	gtk_container_add (GTK_CONTAINER (align), GTK_WIDGET (section->childbox));
 
 	section->title = gtk_label_new (title_markup);

--- a/libslab/slab-section.h
+++ b/libslab/slab-section.h
@@ -47,7 +47,7 @@ typedef enum
 
 typedef struct
 {
-	GtkVBox parent_vbox;
+	GtkBox parent_vbox;
 
 	GtkWidget *title;
 	GtkWidget *contents;
@@ -59,7 +59,7 @@ typedef struct
 
 typedef struct
 {
-	GtkVBoxClass parent_class;
+	GtkBoxClass parent_class;
 } SlabSectionClass;
 
 GType slab_section_get_type (void);


### PR DESCRIPTION
and fix deprecated usage of GtkHBox and GtkVBox in GTK+3 build

@flexiondotorg @sunweaver @gnugr: this commit changes the public interface of libslab in both GTK+ builds (due to transition of classes' parents and/or members from GtkVBox to GtkBox). So a rebuild of ```gnome-main-menu``` might be needed after this. However, I found out that g-m-m crashes with mate-panel 1.12 anyway, no matter if I rebuild it or not...

