### PR TITLE
Fix mate-display-properties with glib2.49

### DIFF
--- a/capplets/display/scrollarea.c
+++ b/capplets/display/scrollarea.c
@@ -324,7 +324,7 @@ foo_scroll_area_class_init (FooScrollAreaClass *class)
 		      G_STRUCT_OFFSET (FooScrollAreaClass,
 				       paint),
 		      NULL, NULL,
-		      foo_marshal_VOID__POINTER_BOXED_POINTER,
+		      g_cclosure_marshal_VOID__POINTER,
 		      G_TYPE_NONE,
 #if GTK_CHECK_VERSION (3, 0, 0)
                       1,

--- a/capplets/display/scrollarea.c
+++ b/capplets/display/scrollarea.c
@@ -324,7 +324,11 @@ foo_scroll_area_class_init (FooScrollAreaClass *class)
 		      G_STRUCT_OFFSET (FooScrollAreaClass,
 				       paint),
 		      NULL, NULL,
+#if GTK_CHECK_VERSION (3, 0, 0)
 		      g_cclosure_marshal_VOID__POINTER,
+#else
+              foo_marshal_VOID__POINTER_BOXED_POINTER,
+#endif
 		      G_TYPE_NONE,
 #if GTK_CHECK_VERSION (3, 0, 0)
                       1,


### PR DESCRIPTION
Fix for https://github.com/mate-desktop/mate-control-center/issues/251

Systematic removal of lines from a patch between master and the oldest version that could be bullt from the gnome-control-center 3.0 development cycle revealed g_cclosure_marshal_VOID__POINTER to be the reason the cinnamon and GNOME applets work and mate-display-properties from master does not. Fix this.

TESTING NOTE: Does this work with GTK2 and older Glib versions? Glib should be fine because GNOME and Cinnamon have used this code for several years but GTK2 may need a test. Is this even broken in GTK2 or only in GTK3 anyway? I have no way to test that, but it can go behind #ifdefs if necessary.