### PR TITLE
fix uk translation

### DIFF
--- a/po/uk.po
+++ b/po/uk.po
@@ -111,11 +111,11 @@ msgstr "URL за яким можна отримати додаткові тем�
 
 #: ../org.mate.control-center.keybinding.gschema.xml.in.h:1
 msgid "Keybinding"
-msgstr "Сполучення клявіш"
+msgstr "Сполучення клавіш"
 
 #: ../org.mate.control-center.keybinding.gschema.xml.in.h:2
 msgid "Keybinding associated with a custom shortcut."
-msgstr "Сполучення клявіш, що асоціюється з користувацьким посиланням"
+msgstr "Сполучення клавіш, що асоціюється з користувацьким посиланням"
 
 #: ../org.mate.control-center.keybinding.gschema.xml.in.h:3
 msgid "Command"
@@ -123,7 +123,7 @@ msgstr "Команда"
 
 #: ../org.mate.control-center.keybinding.gschema.xml.in.h:4
 msgid "Command associated with a custom keybinding."
-msgstr "Команда, що асоціюється з користувацькими сполученнями клявіш."
+msgstr "Команда, що асоціюється з користувацькими сполученнями клавіш."
 
 #: ../org.mate.control-center.keybinding.gschema.xml.in.h:5
 msgid "Name"
@@ -131,7 +131,7 @@ msgstr "Назва"
 
 #: ../org.mate.control-center.keybinding.gschema.xml.in.h:6
 msgid "Description associated with a custom keybinding."
-msgstr "Опис, асоційований з користувацькими сполученнями клявіш"
+msgstr "Опис, асоційований з користувацькими сполученнями клавіш"
 
 #: ../capplets/about-me/eel-alert-dialog.c:110
 msgid "Image/label border"


### PR DESCRIPTION
It should be changed in all cases in all language files:
1. "Иньш" -> "Інш", "иньш" -> "інш";
2. "Кляв" -> "Клав", "кляв" -> "клав".
// Sergiy Gorichenko