### PR TITLE
Fix live updating of some theme interface elements

### DIFF
--- a/capplets/appearance/appearance-style.c
+++ b/capplets/appearance/appearance-style.c
@@ -980,6 +980,7 @@ prepare_list (AppearanceData *data, GtkWidget *list, ThemeType type, GCallback c
   gchar *signal_name = g_strdup_printf("changed::%s", key);
   g_signal_connect (settings, signal_name,
       G_CALLBACK (treeview_gsettings_changed_callback), list);
+  g_signal_connect (settings, signal_name, callback, data);
   g_free (signal_name);
 
   /* connect to treeview change event */

--- a/capplets/appearance/appearance-style.c
+++ b/capplets/appearance/appearance-style.c
@@ -955,9 +955,9 @@ prepare_list (AppearanceData *data, GtkWidget *list, ThemeType type, GCallback c
   conv_data->thumbnail = thumbnail;
   
   /* set useful data for callbacks */
-  g_object_set_data (G_OBJECT (list), THEME_DATA, conv_data);
+  g_object_set_data_full (G_OBJECT (list), THEME_DATA, conv_data, g_free);
   g_object_set_data (G_OBJECT (list), GSETTINGS_SETTINGS, settings);
-  g_object_set_data (G_OBJECT (list), GSETTINGS_KEY, g_strdup(key));
+  g_object_set_data_full (G_OBJECT (list), GSETTINGS_KEY, g_strdup(key), g_free);
   
   /* select in treeview the theme set in gsettings */
   GtkTreeModel *treemodel;


### PR DESCRIPTION
Fix list-specific live updates, like whether the theme can be deleted, or the available cursor sizes for the current theme.

This got lost in GSettings migration in b3e27b1d6a0f11c5835f5829bac3861e2147b17e.  The initial value update was restored in 070e7cb765a788c8e27ff3615d3ed36981d3518d.

Note: as signals handlers are called in the order they are registered, the specific one will run after the generic one, so the generic updates will have been applied.

----
The leaks fix is unrelated, and can be split out it you want.