### PR TITLE
file-transfer-dialog: port to GtkGrid

### DIFF
--- a/capplets/common/file-transfer-dialog.c
+++ b/capplets/common/file-transfer-dialog.c
@@ -292,7 +292,6 @@ file_transfer_dialog_init (FileTransferDialog *dlg)
 	GtkWidget *vbox;
 	GtkWidget *hbox;
 	GtkWidget *progress_vbox;
-	GtkWidget *table;
 	char      *markup;
 	GtkWidget *content_area;
 
@@ -326,11 +325,6 @@ file_transfer_dialog_init (FileTransferDialog *dlg)
 	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
 
-	table = gtk_table_new (2, 2, FALSE);
-	gtk_table_set_row_spacings (GTK_TABLE (table), 4);
-	gtk_table_set_col_spacings (GTK_TABLE (table), 4);
-
-	gtk_box_pack_start (GTK_BOX (vbox), GTK_WIDGET (table), FALSE, FALSE, 0);
 	progress_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 	gtk_box_pack_start (GTK_BOX (vbox), progress_vbox, FALSE, FALSE, 0);
 


### PR DESCRIPTION
I am not sure about this one as i couldn't trigger the gui for it.
Code says it is in capplets/appearance/theme-installer.c .
Any way, this is last GtkTable in our code which is possible to port to GtkGrid.
I guess the rest of GtkTable widgets in m-c-c needs a complete rewrite of the code, as for widgets like gtk_table_resize or gtk_table_get_size there is no replacement in GtkGrid.