### PR TITLE
avoid deprecated GtkAlignment

### DIFF
--- a/capplets/common/theme-thumbnail.c
+++ b/capplets/common/theme-thumbnail.c
@@ -171,7 +171,6 @@ create_meta_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
   GtkWidget *window;
   GtkWidget *preview;
   GtkWidget *vbox;
-  GtkWidget *align;
   GtkWidget *box;
   GtkWidget *stock_button;
   GtkWidget *checkbox;
@@ -221,10 +220,11 @@ create_meta_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
   gtk_container_add (GTK_CONTAINER (preview), vbox);
-  align = gtk_alignment_new (0, 0, 0.0, 0.0);
-  gtk_box_pack_start (GTK_BOX (vbox), align, FALSE, FALSE, 0);
   stock_button = gtk_button_new_from_stock (GTK_STOCK_OPEN);
-  gtk_container_add (GTK_CONTAINER (align), stock_button);
+  gtk_widget_set_halign (stock_button, GTK_ALIGN_START);
+  gtk_widget_set_valign (stock_button, GTK_ALIGN_START);
+  gtk_widget_show (stock_button);
+  gtk_box_pack_start (GTK_BOX (vbox), stock_button, FALSE, FALSE, 0);
   box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start (GTK_BOX (vbox), box, FALSE, FALSE, 0);
   checkbox = gtk_check_button_new ();

--- a/capplets/keyboard/mate-keyboard-properties-xkbot.c
+++ b/capplets/keyboard/mate-keyboard-properties-xkbot.c
@@ -304,7 +304,7 @@ static void
 xkb_options_add_group (XklConfigRegistry * config_registry,
 		       XklConfigItem * config_item, GtkBuilder * dialog)
 {
-	GtkWidget *align, *vbox, *option_check;
+	GtkWidget *vbox, *option_check;
 	gboolean allow_multiple_selection =
 	    GPOINTER_TO_INT (g_object_get_data (G_OBJECT (config_item),
 						XCI_PROP_ALLOW_MULTIPLE_SELECTION));
@@ -325,11 +325,15 @@ xkb_options_add_group (XklConfigRegistry * config_registry,
 				g_strdup (config_item->name), g_free);
 
 	g_free (titlemarkup);
-	align = gtk_alignment_new (0, 0, 1, 1);
-	gtk_alignment_set_padding (GTK_ALIGNMENT (align), 6, 12, 12, 0);
 	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
-	gtk_container_add (GTK_CONTAINER (align), vbox);
-	gtk_container_add (GTK_CONTAINER (current_expander), align);
+	gtk_widget_set_halign (vbox, GTK_ALIGN_FILL);
+	gtk_widget_set_valign (vbox, GTK_ALIGN_START);
+	gtk_widget_set_hexpand (vbox, TRUE);
+	gtk_widget_set_vexpand (vbox, TRUE);
+	gtk_widget_set_margin_top (vbox, 6);
+	gtk_widget_set_margin_bottom (vbox, 12);
+	gtk_widget_set_margin_start (vbox, 12);
+	gtk_container_add (GTK_CONTAINER (current_expander), vbox);
 
 	current_multi_select = (gboolean) allow_multiple_selection;
 	current_radio_group = NULL;


### PR DESCRIPTION
Indeed this is the close button in the thumbnail, so you need to clear the thumbnail cache for testing
~.cache/thumbnails/normal
~.cache/thumbnails/fail