### PR TITLE
Add support for switching themes on Metacity >= 3.20.

### DIFF
--- a/capplets/appearance/appearance-support.c
+++ b/capplets/appearance/appearance-support.c
@@ -77,7 +77,7 @@ metacity_theme_apply(const gchar *theme, const gchar *font)
     {
         gchar *gsettings_cmd = NULL;
 
-        /* for metacity <= 3.12 */
+        /* for GNOME3 */
         gsettings_cmd = g_strdup_printf("gsettings set org.gnome.desktop.wm.preferences theme '%s'", theme);
         g_spawn_command_line_async (gsettings_cmd, NULL);
         g_free (gsettings_cmd);
@@ -88,6 +88,11 @@ metacity_theme_apply(const gchar *theme, const gchar *font)
 
         /* for metacity >= 3.16 */
         gsettings_cmd = g_strdup_printf("gsettings set org.gnome.metacity theme '%s'", theme);
+        g_spawn_command_line_async (gsettings_cmd, NULL);
+        g_free (gsettings_cmd);
+
+        /* for metacity >= 3.20 */
+        gsettings_cmd = g_strdup_printf("gsettings set org.gnome.metacity.theme name '%s'", theme);
         g_spawn_command_line_async (gsettings_cmd, NULL);
         g_free (gsettings_cmd);
     }


### PR DESCRIPTION
This pull request adds support for switching themes for Metacity >= 3.20, when the schema changed again. Support for Metacity <= 3.318 has been retained for those needing it. The keys previously used by Metacity >= 3.12 are still relevant for use by GNOME3.