### PR TITLE
keybindings: Fix and add mnemonics in the custom command dialog

### DIFF
--- a/capplets/keybindings/mate-keybinding-properties.ui
+++ b/capplets/keybindings/mate-keybinding-properties.ui
@@ -97,6 +97,7 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="top_attach">0</property>
+                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
@@ -106,6 +107,7 @@
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">C_ommand:</property>
                     <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">custom-shortcut-command-entry</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -113,40 +115,28 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkEntry" id="custom-shortcut-command-entry">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkEntry" id="custom-shortcut-command-entry">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="hexpand">True</property>
-                        <property name="invisible_char">•</property>
-                        <property name="activates_default">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="custom-shortcut-command-button">
-                        <property name="label" translatable="yes">Browse applications...</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="invisible_char">•</property>
+                    <property name="activates_default">True</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="custom-shortcut-command-button">
+                    <property name="label" translatable="yes">_Browse applications...</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>


### PR DESCRIPTION
Also remove an unnecessary intermediate box, we can pack in the grid
directly.

Fix for breakage introduced in #274.