### PR TITLE
libslab: correct icon loading code

### DIFF
--- a/libslab/mate-utils.c
+++ b/libslab/mate-utils.c
@@ -55,10 +55,11 @@ load_image_by_id (GtkImage * image, GtkIconSize size, const gchar * image_id)
 		else
 			icon_theme = gtk_icon_theme_get_default ();
 
-		icon_exists = gtk_icon_theme_has_icon (icon_theme, id);
-
-		if (icon_exists)
-			gtk_image_set_from_icon_name (image, id, size);
+		pixbuf = gtk_icon_theme_load_icon (icon_theme, id, width, 0, NULL);
+		if (pixbuf != NULL) {
+			gtk_image_set_from_pixbuf (image, pixbuf);
+			g_object_unref (pixbuf);
+		}
 		else
 			gtk_image_set_from_icon_name (image, "image-missing", size);
 

--- a/libslab/themed-icon.c
+++ b/libslab/themed-icon.c
@@ -29,7 +29,7 @@ static void themed_icon_get_property (GObject *, guint, GValue *, GParamSpec *);
 static void themed_icon_set_property (GObject *, guint, const GValue *, GParamSpec *);
 
 static void themed_icon_show (GtkWidget *);
-static void themed_icon_style_set (GtkWidget *, GtkStyle *);
+static void themed_icon_style_updated (GtkWidget *);
 
 enum
 {
@@ -57,7 +57,7 @@ static void themed_icon_class_init (ThemedIconClass * themed_icon_class)
 	g_obj_class->finalize = themed_icon_finalize;
 
 	widget_class->show = themed_icon_show;
-	widget_class->style_set = themed_icon_style_set;
+	widget_class->style_updated = themed_icon_style_updated;
 
 	g_type_class_add_private (themed_icon_class, sizeof (ThemedIconPrivate));
 
@@ -157,7 +157,7 @@ themed_icon_show (GtkWidget * widget)
 }
 
 static void
-themed_icon_style_set (GtkWidget * widget, GtkStyle * prev_style)
+themed_icon_style_updated (GtkWidget * widget)
 {
 	ThemedIcon *icon = THEMED_ICON (widget);
 


### PR DESCRIPTION
fixes loading app icons from /usr/share/pixmaps when the icon theme
doesn't have an icon with chosen name

fixes https://github.com/mate-desktop/mate-control-center/issues/283