### PR TITLE
mouse: warn about enabling multi-finger emulation

### DIFF
--- a/capplets/mouse/mate-mouse-properties.ui
+++ b/capplets/mouse/mate-mouse-properties.ui
@@ -1008,6 +1008,25 @@
                         <property name="position">3</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkLabel" id="multi_finger_warning">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_top">5</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Warning: multi-finger emulation may disable software buttons</property>
+                        <attributes>
+                          <attribute name="style" value="italic"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
libinput is the new default driver for touchpads and unlike the synaptics driver, it disables software buttons when clickfinger is enabled.

This commit introduces a warning message about this situation in the touchpad dialog. This message only appears when some multi-finger click emulation is enabled.

See https://bugzilla.redhat.com/show_bug.cgi?id=1465115

Thanks for considering it.