### PR TITLE
avoid some GdkScreen deprecations

### DIFF
--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -425,11 +425,13 @@ get_dpi_from_x_server (void)
   screen = gdk_screen_get_default ();
   if (screen) {
     double width_dpi, height_dpi;
+    gint sc_width, sc_height;
 
-    width_dpi = dpi_from_pixels_and_mm (gdk_screen_get_width (screen),
-					gdk_screen_get_width_mm (screen));
-    height_dpi = dpi_from_pixels_and_mm (gdk_screen_get_height (screen),
-					 gdk_screen_get_height_mm (screen));
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+			     &sc_width, &sc_height);
+
+    width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
+    height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
 
     if (width_dpi < DPI_LOW_REASONABLE_VALUE || width_dpi > DPI_HIGH_REASONABLE_VALUE ||
         height_dpi < DPI_LOW_REASONABLE_VALUE || height_dpi > DPI_HIGH_REASONABLE_VALUE)

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -419,10 +419,18 @@ dpi_from_pixels_and_mm (int pixels, int mm)
 static double
 get_dpi_from_x_server (void)
 {
-  GdkScreen *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+  GdkDisplay *display;
+  GdkMonitor *monitor;
+#endif
+  GdkScreen  *screen;
   double dpi;
 
   screen = gdk_screen_get_default ();
+#if GTK_CHECK_VERSION (3, 22, 0)
+  display = gdk_screen_get_display (screen);
+  monitor = gdk_display_get_primary_monitor (display);
+#endif
   if (screen) {
     double width_dpi, height_dpi;
     gint sc_width, sc_height;
@@ -430,8 +438,13 @@ get_dpi_from_x_server (void)
     gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
 			     &sc_width, &sc_height);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+    width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_monitor_get_width_mm (monitor));
+    height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_monitor_get_height_mm (monitor));
+#else
     width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
     height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
+#endif
 
     if (width_dpi < DPI_LOW_REASONABLE_VALUE || width_dpi > DPI_HIGH_REASONABLE_VALUE ||
         height_dpi < DPI_LOW_REASONABLE_VALUE || height_dpi > DPI_HIGH_REASONABLE_VALUE)

--- a/libslab/app-shell.c
+++ b/libslab/app-shell.c
@@ -256,6 +256,7 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 	GtkWidget *left_vbox;
 	GtkWidget *right_vbox;
 	gint num_cols;
+	gint sc_width;
 
 	GtkWidget *sw;
 	GtkAdjustment *adjustment;
@@ -265,10 +266,13 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 
 	right_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
+	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+				 NULL, NULL, &sc_width, NULL);
+
 	num_cols = SIZING_SCREEN_WIDTH_LARGE_NUMCOLS;
-	if (gdk_screen_width () <= SIZING_SCREEN_WIDTH_LARGE)
+	if (sc_width <= SIZING_SCREEN_WIDTH_LARGE)
 	{
-		if (gdk_screen_width () <= SIZING_SCREEN_WIDTH_MEDIUM)
+		if (sc_width <= SIZING_SCREEN_WIDTH_MEDIUM)
 			num_cols = SIZING_SCREEN_WIDTH_SMALL_NUMCOLS;
 		else
 			num_cols = SIZING_SCREEN_WIDTH_MEDIUM_NUMCOLS;

--- a/libslab/shell-window.c
+++ b/libslab/shell-window.c
@@ -113,8 +113,13 @@ shell_window_handle_size_request (GtkWidget * widget, GtkRequisition * requisiti
 	height = child_requisiton.height + 10;
 	if (height > requisition->height)
 	{
+		gint sc_height;
+
+		gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+					 NULL, NULL, NULL, &sc_height);
+
 		requisition->height =
-			MIN (((gfloat) gdk_screen_height () * SIZING_HEIGHT_PERCENT), height);
+			MIN (((gfloat) sc_height * SIZING_HEIGHT_PERCENT), height);
 	}
 }
 

--- a/typing-break/drw-break-window.c
+++ b/typing-break/drw-break-window.c
@@ -127,6 +127,8 @@ drw_break_window_init (DrwBreakWindow *window)
 	gint                   root_monitor = 0;
 	GdkScreen             *screen = NULL;
 	GdkRectangle           monitor;
+	gint                   sc_width;
+	gint                   sc_height;
 	gint                   right_padding;
 	gint                   bottom_padding;
 	GSettings             *settings;
@@ -149,16 +151,17 @@ drw_break_window_init (DrwBreakWindow *window)
 	screen = gdk_screen_get_default ();
 	gdk_screen_get_monitor_geometry (screen, root_monitor, &monitor);
 
-	gtk_window_set_default_size (GTK_WINDOW (window),
-				     gdk_screen_get_width (screen),
-				     gdk_screen_get_height (screen));
+	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+				 &sc_width, &sc_height);
+
+	gtk_window_set_default_size (GTK_WINDOW (window), sc_width, sc_height);
 
 	gtk_window_set_decorated (GTK_WINDOW (window), FALSE);
 	gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
 	drw_setup_background (GTK_WIDGET (window));
 
-	right_padding = gdk_screen_get_width (screen) - monitor.width - monitor.x;
-	bottom_padding = gdk_screen_get_height (screen) - monitor.height - monitor.y;
+	right_padding = sc_width - monitor.width - monitor.x;
+	bottom_padding = sc_height - monitor.height - monitor.y;
 
 	outer_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 	gtk_widget_set_hexpand (outer_vbox, TRUE);

--- a/typing-break/drw-utils.c
+++ b/typing-break/drw-utils.c
@@ -124,8 +124,9 @@ set_pixmap_background (GtkWidget *window)
 	gtk_widget_realize (window);
 
 	screen = gtk_widget_get_screen (window);
-	width = gdk_screen_get_width (screen);
-	height = gdk_screen_get_height (screen);
+
+	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+				 &width, &height);
 
 	tmp_pixbuf = gdk_pixbuf_get_from_window (gdk_screen_get_root_window (screen),
 						 0,

--- a/typing-break/drwright.c
+++ b/typing-break/drwright.c
@@ -778,15 +778,18 @@ create_secondary_break_windows (void)
 	if (screen != gdk_screen_get_default ()) {
 		/* Handled by DrwBreakWindow. */
 
+		gint sc_width, sc_height;
+
 		window = gtk_window_new (GTK_WINDOW_POPUP);
 
 		windows = g_list_prepend (windows, window);
 
 		gtk_window_set_screen (GTK_WINDOW (window), screen);
 
-		gtk_window_set_default_size (GTK_WINDOW (window),
-					     gdk_screen_get_width (screen),
-					     gdk_screen_get_height (screen));
+		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+					 &sc_width, &sc_height);
+
+		gtk_window_set_default_size (GTK_WINDOW (window), sc_width, sc_height);
 
 		gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
 		drw_setup_background (GTK_WIDGET (window));


### PR DESCRIPTION
avoid deprecated:

- gdk_screen_get_width/height

- gdk_screen_get_width/height_mm

- gdk_screen_width/height
