### PR TITLE
gtk 3.22: avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/capplets/appearance/appearance-desktop.c
+++ b/capplets/appearance/appearance-desktop.c
@@ -883,11 +883,20 @@ static gdouble
 get_monitor_aspect_ratio_for_widget (GtkWidget *widget)
 {
   gdouble aspect;
+#if GTK_CHECK_VERSION (3, 22, 0)
+  GdkMonitor *monitor;
+#else
   gint monitor;
+#endif
   GdkRectangle rect;
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+  monitor = gdk_display_get_monitor_at_window (gtk_widget_get_display (widget), gtk_widget_get_window (widget));
+  gdk_monitor_get_geometry (monitor, &rect);
+#else
   monitor = gdk_screen_get_monitor_at_window (gtk_widget_get_screen (widget), gtk_widget_get_window (widget));
   gdk_screen_get_monitor_geometry (gtk_widget_get_screen (widget), monitor, &rect);
+#endif
   aspect = rect.height / (gdouble)rect.width;
 
   return aspect;

--- a/typing-break/drw-break-window.c
+++ b/typing-break/drw-break-window.c
@@ -126,6 +126,9 @@ drw_break_window_init (DrwBreakWindow *window)
 
 	gint                   root_monitor = 0;
 	GdkScreen             *screen = NULL;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay            *display;
+#endif
 	GdkRectangle           monitor;
 	gint                   sc_width;
 	gint                   sc_height;
@@ -149,7 +152,12 @@ drw_break_window_init (DrwBreakWindow *window)
 	gtk_window_set_modal (GTK_WINDOW (window), TRUE);
 
 	screen = gdk_screen_get_default ();
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
+	gdk_monitor_get_geometry (gdk_display_get_monitor (display, root_monitor), &monitor);
+#else
 	gdk_screen_get_monitor_geometry (screen, root_monitor, &monitor);
+#endif
 
 	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
 				 &sc_width, &sc_height);


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_window