### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -420,53 +420,18 @@ dpi_from_pixels_and_mm (int pixels, int mm)
 static double
 get_dpi_from_x_server (void)
 {
-#if GTK_CHECK_VERSION (3, 22, 0)
-  GdkDisplay *display;
-  GdkMonitor *monitor;
-#endif
   GdkScreen  *screen;
   double dpi;
 
   screen = gdk_screen_get_default ();
-#if GTK_CHECK_VERSION (3, 22, 0)
-  display = gdk_screen_get_display (screen);
-  monitor = gdk_display_get_primary_monitor (display);
-#endif
+
   if (screen) {
     double width_dpi, height_dpi;
-    gint sc_width = 0;
-    gint sc_height = 0;
-#if GTK_CHECK_VERSION (3, 22, 0)
-    gint n =0;
-    gint i = 0;
-    GdkRectangle geometry;
 
-    n = gdk_display_get_n_monitors (display);
-
-    for (i = 0; i < n; ++i)
-    {
-      monitor = gdk_display_get_monitor (display, i);
-
-      gdk_monitor_get_geometry (monitor, &geometry);
-      sc_width = sc_width + geometry.width;
-
-      if (geometry.height > sc_height)
-        sc_height = sc_height + geometry.height;
-    }
-#else
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-			     &sc_width, &sc_height);
-#endif
-
-#if GTK_CHECK_VERSION (3, 22, 0)
     Screen *xscreen = gdk_x11_screen_get_xscreen (screen);
 
-    width_dpi = dpi_from_pixels_and_mm (sc_width, WidthMMOfScreen (xscreen));
-    height_dpi = dpi_from_pixels_and_mm (sc_height, HeightMMOfScreen (xscreen));
-#else
-    width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
-    height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
-#endif
+    width_dpi = dpi_from_pixels_and_mm (WidthOfScreen (xscreen), WidthMMOfScreen (xscreen));
+    height_dpi = dpi_from_pixels_and_mm (HeightOfScreen (xscreen), HeightMMOfScreen (xscreen));
 
     if (width_dpi < DPI_LOW_REASONABLE_VALUE || width_dpi > DPI_HIGH_REASONABLE_VALUE ||
         height_dpi < DPI_LOW_REASONABLE_VALUE || height_dpi > DPI_HIGH_REASONABLE_VALUE)

--- a/libslab/app-shell.c
+++ b/libslab/app-shell.c
@@ -25,6 +25,7 @@
 #include <libmate-desktop/mate-desktop-item.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -256,7 +257,6 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 	GtkWidget *left_vbox;
 	GtkWidget *right_vbox;
 	gint num_cols;
-	gint sc_width;
 
 	GtkWidget *sw;
 	GtkAdjustment *adjustment;
@@ -266,13 +266,10 @@ layout_shell (AppShellData * app_data, const gchar * filter_title, const gchar *
 
 	right_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-				 NULL, NULL, &sc_width, NULL);
-
 	num_cols = SIZING_SCREEN_WIDTH_LARGE_NUMCOLS;
-	if (sc_width <= SIZING_SCREEN_WIDTH_LARGE)
+	if (WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) <= SIZING_SCREEN_WIDTH_LARGE)
 	{
-		if (sc_width <= SIZING_SCREEN_WIDTH_MEDIUM)
+		if (WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) <= SIZING_SCREEN_WIDTH_MEDIUM)
 			num_cols = SIZING_SCREEN_WIDTH_SMALL_NUMCOLS;
 		else
 			num_cols = SIZING_SCREEN_WIDTH_MEDIUM_NUMCOLS;

--- a/libslab/shell-window.c
+++ b/libslab/shell-window.c
@@ -21,6 +21,7 @@
 #include "shell-window.h"
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include "app-resizer.h"
 
@@ -113,13 +114,8 @@ shell_window_handle_size_request (GtkWidget * widget, GtkRequisition * requisiti
 	height = child_requisiton.height + 10;
 	if (height > requisition->height)
 	{
-		gint sc_height;
-
-		gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-					 NULL, NULL, NULL, &sc_height);
-
 		requisition->height =
-			MIN (((gfloat) sc_height * SIZING_HEIGHT_PERCENT), height);
+			MIN (((gfloat) HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) * SIZING_HEIGHT_PERCENT), height);
 	}
 }
 

--- a/typing-break/drw-break-window.c
+++ b/typing-break/drw-break-window.c
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <gio/gio.h>
 
@@ -130,8 +131,6 @@ drw_break_window_init (DrwBreakWindow *window)
 	GdkDisplay            *display;
 #endif
 	GdkRectangle           monitor;
-	gint                   sc_width;
-	gint                   sc_height;
 	gint                   right_padding;
 	gint                   bottom_padding;
 	GSettings             *settings;
@@ -159,17 +158,16 @@ drw_break_window_init (DrwBreakWindow *window)
 	gdk_screen_get_monitor_geometry (screen, root_monitor, &monitor);
 #endif
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &sc_width, &sc_height);
-
-	gtk_window_set_default_size (GTK_WINDOW (window), sc_width, sc_height);
+	gtk_window_set_default_size (GTK_WINDOW (window),
+				     WidthOfScreen (gdk_x11_screen_get_xscreen (screen)),
+				     HeightOfScreen (gdk_x11_screen_get_xscreen (screen)));
 
 	gtk_window_set_decorated (GTK_WINDOW (window), FALSE);
 	gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
 	drw_setup_background (GTK_WIDGET (window));
 
-	right_padding = sc_width - monitor.width - monitor.x;
-	bottom_padding = sc_height - monitor.height - monitor.y;
+	right_padding = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) - monitor.width - monitor.x;
+	bottom_padding = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) - monitor.height - monitor.y;
 
 	outer_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 	gtk_widget_set_hexpand (outer_vbox, TRUE);

--- a/typing-break/drw-utils.c
+++ b/typing-break/drw-utils.c
@@ -20,6 +20,7 @@
 
 #include <config.h>
 #include <gdk/gdk.h>
+#include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include "drw-utils.h"
 
@@ -124,9 +125,8 @@ set_pixmap_background (GtkWidget *window)
 	gtk_widget_realize (window);
 
 	screen = gtk_widget_get_screen (window);
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &width, &height);
+	width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+	height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
 	tmp_pixbuf = gdk_pixbuf_get_from_window (gdk_screen_get_root_window (screen),
 						 0,

--- a/typing-break/drwright.c
+++ b/typing-break/drwright.c
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <glib/gi18n.h>
 #include <gdk/gdk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <gio/gio.h>
@@ -811,18 +812,15 @@ create_secondary_break_windows (void)
 	if (screen != gdk_screen_get_default ()) {
 		/* Handled by DrwBreakWindow. */
 
-		gint sc_width, sc_height;
-
 		window = gtk_window_new (GTK_WINDOW_POPUP);
 
 		windows = g_list_prepend (windows, window);
 
 		gtk_window_set_screen (GTK_WINDOW (window), screen);
 
-		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-					 &sc_width, &sc_height);
-
-		gtk_window_set_default_size (GTK_WINDOW (window), sc_width, sc_height);
+		gtk_window_set_default_size (GTK_WINDOW (window),
+					     WidthOfScreen (gdk_x11_screen_get_xscreen (screen)),
+					     HeightOfScreen (gdk_x11_screen_get_xscreen (screen)));
 
 		gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
 		drw_setup_background (GTK_WIDGET (window));


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-control-center/commit/fe782c673262e861334bb48265abf5075ff02680
https://github.com/mate-desktop/mate-control-center/commit/061f3780a3af6224a804d239f9b9dfc5c81873f6

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height

gdk_screen_width
gdk_screen_height