### PR TITLE
Fix Window Border theme cannot be deleted

### DIFF
--- a/capplets/appearance/theme-installer.c
+++ b/capplets/appearance/theme-installer.c
@@ -310,10 +310,6 @@ mate_theme_install_real (GtkWindow *parent,
 					   theme_name, NULL);
 		break;
 	case THEME_MATE:
-		target_dir = g_build_path (G_DIR_SEPARATOR_S,
-					   g_get_home_dir (), ".themes",
-			 		   theme_name, NULL);
-		break;
 	case THEME_MARCO:
 	case THEME_GTK:
 		target_dir = g_build_path (G_DIR_SEPARATOR_S,

--- a/capplets/appearance/theme-util.c
+++ b/capplets/appearance/theme-util.c
@@ -95,7 +95,7 @@ gboolean theme_delete (const gchar *name, ThemeType type)
 
     case THEME_TYPE_WINDOW:
       theme = (MateThemeCommonInfo *) mate_theme_info_find (name);
-      theme_dir = g_build_filename (theme->path, "marco-1", NULL);
+      theme_dir = g_build_filename (theme->path, "metacity-1", NULL);
       break;
 
     case THEME_TYPE_META:


### PR DESCRIPTION
The directory "marco-1" does not exist, replacing it  with
"metacity-1".

Fixes #316

Signed-off-by: Zhang Xianwei <zhang.xianwei8@zte.com.cn>