### PR TITLE
theme-util.c: fix reinstalling the deleted theme can cause failure

### DIFF
--- a/capplets/appearance/theme-installer.c
+++ b/capplets/appearance/theme-installer.c
@@ -491,6 +491,8 @@ mate_theme_install_real (GtkWindow *parent,
 	}
 
 	g_free (target_dir);
+	g_object_unref (theme_source_dir);
+	g_object_unref (theme_dest_dir);
 
 	return success;
 }

--- a/capplets/appearance/theme-util.c
+++ b/capplets/appearance/theme-util.c
@@ -99,8 +99,9 @@ gboolean theme_delete (const gchar *name, ThemeType type)
       break;
 
     case THEME_TYPE_META:
-      theme = (MateThemeCommonInfo *) mate_theme_meta_info_find (name);
+      theme = (MateThemeCommonInfo *) mate_theme_info_find (name);
       theme_dir = g_strdup (theme->path);
+      del_empty_parent = FALSE;
       break;
 
     case THEME_TYPE_CURSOR:


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-control-center/issues/322

Signed-off-by: Zhang Xianwei <zhang.xianwei8@zte.com.cn>
@raveit65 