### PR TITLE
avoid deprecated GtkStock

### DIFF
--- a/capplets/about-me/mate-about-me-fingerprint.c
+++ b/capplets/about-me/mate-about-me-fingerprint.c
@@ -219,7 +219,7 @@ delete_fingerprints_question (GtkBuilder *dialog, GtkWidget *enable, GtkWidget *
 					   GTK_MESSAGE_QUESTION,
 					   GTK_BUTTONS_NONE,
 					   _("Delete registered fingerprints?"));
-	gtk_dialog_add_button (GTK_DIALOG (question), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+	gtk_dialog_add_button (GTK_DIALOG (question), "gtk-cancel", GTK_RESPONSE_CANCEL);
 
 	button = gtk_button_new_with_mnemonic (_("_Delete Fingerprints"));
 	gtk_button_set_image (GTK_BUTTON (button), gtk_image_new_from_icon_name ("edit-delete", GTK_ICON_SIZE_BUTTON));

--- a/capplets/about-me/mate-about-me.c
+++ b/capplets/about-me/mate-about-me.c
@@ -268,8 +268,8 @@ about_me_image_clicked_cb (GtkWidget *button, MateAboutMe *me)
 			 gtk_file_chooser_dialog_new (_("Select Image"), GTK_WINDOW (WID ("about-me-dialog")),
 							GTK_FILE_CHOOSER_ACTION_OPEN,
 							_("No Image"), GTK_RESPONSE_NO,
-							GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-							GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
+							"gtk-cancel", GTK_RESPONSE_CANCEL,
+							"gtk-open", GTK_RESPONSE_ACCEPT,
 							NULL));
 	gtk_window_set_modal (GTK_WINDOW (chooser_dialog), TRUE);
 	gtk_dialog_set_default_response (GTK_DIALOG (chooser_dialog), GTK_RESPONSE_ACCEPT);

--- a/capplets/appearance/appearance-desktop.c
+++ b/capplets/appearance/appearance-desktop.c
@@ -615,9 +615,9 @@ wp_create_filechooser (AppearanceData *data)
                      gtk_file_chooser_dialog_new (_("Add Wallpaper"),
                      GTK_WINDOW (appearance_capplet_get_widget (data, "appearance_window")),
                      GTK_FILE_CHOOSER_ACTION_OPEN,
-                     GTK_STOCK_CANCEL,
+                     "gtk-cancel",
                      GTK_RESPONSE_CANCEL,
-                     GTK_STOCK_OPEN,
+                     "gtk-open",
                      GTK_RESPONSE_OK,
                      NULL));
 

--- a/capplets/appearance/appearance-themes.c
+++ b/capplets/appearance/appearance-themes.c
@@ -1089,7 +1089,7 @@ void themes_init(AppearanceData* data)
 
   w = appearance_capplet_get_widget (data, "theme_custom");
   gtk_button_set_image (GTK_BUTTON (w),
-                        gtk_image_new_from_stock (GTK_STOCK_EDIT, GTK_ICON_SIZE_BUTTON));
+                        gtk_image_new_from_icon_name ("gtk-edit", GTK_ICON_SIZE_BUTTON));
   g_signal_connect (w, "clicked", (GCallback) theme_custom_cb, data);
 
   del_button = appearance_capplet_get_widget (data, "theme_delete");

--- a/capplets/appearance/theme-installer.c
+++ b/capplets/appearance/theme-installer.c
@@ -432,8 +432,8 @@ mate_theme_install_real (GtkWindow *parent,
 
 				apply_button = gtk_button_new_with_label (_("Apply New Theme"));
 				gtk_button_set_image (GTK_BUTTON (apply_button),
-						      gtk_image_new_from_stock (GTK_STOCK_APPLY,
-										GTK_ICON_SIZE_BUTTON));
+						      gtk_image_new_from_icon_name ("gtk-apply",
+										    GTK_ICON_SIZE_BUTTON));
 				gtk_dialog_add_action_widget (GTK_DIALOG (dialog), apply_button, GTK_RESPONSE_APPLY);
 				gtk_widget_set_can_default (apply_button, TRUE);
 				gtk_widget_show (apply_button);
@@ -767,9 +767,9 @@ mate_theme_installer_run (GtkWindow *parent,
 	dialog = gtk_file_chooser_dialog_new (_("Select Theme"),
 					      parent,
 					      GTK_FILE_CHOOSER_ACTION_OPEN,
-					      GTK_STOCK_CANCEL,
+					      "gtk-cancel",
 					      GTK_RESPONSE_REJECT,
-					      GTK_STOCK_OPEN,
+					      "gtk-open",
 					      GTK_RESPONSE_ACCEPT,
 					      NULL);
 	gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_ACCEPT);

--- a/capplets/appearance/theme-util.c
+++ b/capplets/appearance/theme-util.c
@@ -71,7 +71,7 @@ gboolean theme_delete (const gchar *name, ThemeType type)
 						 GTK_MESSAGE_QUESTION,
 						 GTK_BUTTONS_CANCEL,
 						 _("Would you like to delete this theme?"));
-  gtk_dialog_add_button (dialog, GTK_STOCK_DELETE, GTK_RESPONSE_ACCEPT);
+  gtk_dialog_add_button (dialog, "gtk-delete", GTK_RESPONSE_ACCEPT);
   response = gtk_dialog_run (dialog);
   gtk_widget_destroy (GTK_WIDGET (dialog));
   if (response != GTK_RESPONSE_ACCEPT)

--- a/capplets/common/capplet-stock-icons.c
+++ b/capplets/common/capplet-stock-icons.c
@@ -64,7 +64,7 @@ capplet_register_stock_icons (GtkIconFactory *factory)
 
 		if (!filename) {
 		        g_warning (_("Unable to load stock icon '%s'\n"), items[i].name);
-			icon_set = gtk_icon_factory_lookup_default (GTK_STOCK_MISSING_IMAGE);
+			icon_set = gtk_icon_factory_lookup_default ("gtk-missing-image");
 			gtk_icon_factory_add (factory, items[i].stock_id, icon_set);
 			continue;
 		}

--- a/capplets/common/file-transfer-dialog.c
+++ b/capplets/common/file-transfer-dialog.c
@@ -333,7 +333,7 @@ file_transfer_dialog_init (FileTransferDialog *dlg)
 			    dlg->priv->progress, FALSE, FALSE, 0);
 
 	gtk_dialog_add_button (GTK_DIALOG (dlg),
-			       GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+			       "gtk-cancel", GTK_RESPONSE_CANCEL);
 
 	gtk_container_set_border_width (GTK_CONTAINER (dlg), 6);
 
@@ -445,8 +445,8 @@ file_transfer_dialog_overwrite (gpointer user_data)
 
 		button = gtk_button_new_with_label (_("_Overwrite"));
 		gtk_button_set_image (GTK_BUTTON (button),
-				      gtk_image_new_from_stock (GTK_STOCK_APPLY,
-								GTK_ICON_SIZE_BUTTON));
+				      gtk_image_new_from_icon_name ("gtk-apply",
+								    GTK_ICON_SIZE_BUTTON));
 		gtk_dialog_add_action_widget (dialog, button, GTK_RESPONSE_YES);
 		gtk_widget_show (button);
 

--- a/capplets/common/theme-thumbnail.c
+++ b/capplets/common/theme-thumbnail.c
@@ -172,7 +172,7 @@ create_meta_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
   GtkWidget *preview;
   GtkWidget *vbox;
   GtkWidget *box;
-  GtkWidget *stock_button;
+  GtkWidget *image_button;
   GtkWidget *checkbox;
   GtkWidget *radio;
 
@@ -220,11 +220,17 @@ create_meta_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
   gtk_container_add (GTK_CONTAINER (preview), vbox);
-  stock_button = gtk_button_new_from_stock (GTK_STOCK_OPEN);
-  gtk_widget_set_halign (stock_button, GTK_ALIGN_START);
-  gtk_widget_set_valign (stock_button, GTK_ALIGN_START);
-  gtk_widget_show (stock_button);
-  gtk_box_pack_start (GTK_BOX (vbox), stock_button, FALSE, FALSE, 0);
+
+  image_button = GTK_WIDGET (g_object_new (GTK_TYPE_BUTTON,
+					   "label", "gtk-open",
+					   "use-stock", TRUE,
+					   "use-underline", TRUE,
+					   NULL));
+
+  gtk_widget_set_halign (image_button, GTK_ALIGN_START);
+  gtk_widget_set_valign (image_button, GTK_ALIGN_START);
+  gtk_widget_show (image_button);
+  gtk_box_pack_start (GTK_BOX (vbox), image_button, FALSE, FALSE, 0);
   box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start (GTK_BOX (vbox), box, FALSE, FALSE, 0);
   checkbox = gtk_check_button_new ();
@@ -281,7 +287,7 @@ static GdkPixbuf *
 create_gtk_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
 {
   GtkSettings *settings;
-  GtkWidget *window, *vbox, *box, *stock_button, *checkbox, *radio;
+  GtkWidget *window, *vbox, *box, *image_button, *checkbox, *radio;
   GtkRequisition requisition;
   GtkAllocation allocation;
   GdkPixbuf *pixbuf, *retval;
@@ -299,8 +305,14 @@ create_gtk_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
   box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
   gtk_container_set_border_width (GTK_CONTAINER (box), 6);
   gtk_box_pack_start (GTK_BOX (vbox), box, FALSE, FALSE, 0);
-  stock_button = gtk_button_new_from_stock (GTK_STOCK_OPEN);
-  gtk_box_pack_start (GTK_BOX (box), stock_button, FALSE, FALSE, 0);
+
+  image_button = GTK_WIDGET (g_object_new (GTK_TYPE_BUTTON,
+					   "label", "gtk-open",
+					   "use-stock", TRUE,
+					   "use-underline", TRUE,
+					   NULL));
+
+  gtk_box_pack_start (GTK_BOX (box), image_button, FALSE, FALSE, 0);
   checkbox = gtk_check_button_new ();
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (checkbox), TRUE);
   gtk_box_pack_start (GTK_BOX (box), checkbox, FALSE, FALSE, 0);
@@ -309,12 +321,12 @@ create_gtk_theme_pixbuf (ThemeThumbnailData *theme_thumbnail_data)
 
   gtk_widget_show_all (window);
   gtk_widget_show_all (vbox);
-  gtk_widget_realize (stock_button);
-  gtk_widget_realize (gtk_bin_get_child (GTK_BIN (stock_button)));
+  gtk_widget_realize (image_button);
+  gtk_widget_realize (gtk_bin_get_child (GTK_BIN (image_button)));
   gtk_widget_realize (checkbox);
   gtk_widget_realize (radio);
-  gtk_widget_map (stock_button);
-  gtk_widget_map (gtk_bin_get_child (GTK_BIN (stock_button)));
+  gtk_widget_map (image_button);
+  gtk_widget_map (gtk_bin_get_child (GTK_BIN (image_button)));
   gtk_widget_map (checkbox);
   gtk_widget_map (radio);
 

--- a/capplets/windows/mate-metacity-support.c
+++ b/capplets/windows/mate-metacity-support.c
@@ -40,7 +40,7 @@ mate_metacity_config_tool ()
     dialog = GTK_DIALOG (gtk_dialog_new_with_buttons(_("Metacity Preferences"),
                                                      NULL,
                                                      GTK_DIALOG_MODAL,
-                                                     GTK_STOCK_CLOSE,
+                                                     "gtk-close",
                                                      GTK_RESPONSE_CLOSE,
                                                      NULL));
     gtk_window_set_icon_name (GTK_WINDOW (dialog), "preferences-system-windows");

--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -358,9 +358,9 @@ main (int argc, char **argv)
     dialog_win = gtk_dialog_new_with_buttons (_("Window Preferences"),
                                               NULL,
                                               GTK_DIALOG_MODAL,
-                                              GTK_STOCK_HELP,
+                                              "gtk-help",
                                               GTK_RESPONSE_HELP,
-                                              GTK_STOCK_CLOSE,
+                                              "gtk-close",
                                               GTK_RESPONSE_CLOSE,
                                               NULL);
     //gtk_window_set_resizable (GTK_WINDOW (dialog_win), FALSE);

--- a/font-viewer/font-view.c
+++ b/font-viewer/font-view.c
@@ -497,7 +497,7 @@ info_button_clicked_cb (GtkButton *button,
 
     dialog = gtk_dialog_new_with_buttons ( _("Info"), GTK_WINDOW (self->main_window),
                                           GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE,
+                                          "gtk-close", GTK_RESPONSE_CLOSE,
                                           NULL);
     gtk_container_add (GTK_CONTAINER (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), grid);
     g_signal_connect (dialog, "response",

--- a/typing-break/drwright.c
+++ b/typing-break/drwright.c
@@ -135,8 +135,8 @@ static void     init_tray_icon                 (DrWright       *dr);
 static GList *  create_secondary_break_windows (void);
 
 static const GtkActionEntry actions[] = {
-  {"Preferences", GTK_STOCK_PREFERENCES, NULL, NULL, NULL, G_CALLBACK (popup_preferences_cb)},
-  {"About", GTK_STOCK_ABOUT, NULL, NULL, NULL, G_CALLBACK (popup_about_cb)},
+  {"Preferences", "preferences-desktop", N_("_Preferences"), NULL, NULL, G_CALLBACK (popup_preferences_cb)},
+  {"About", "help-about", N_("_About"), NULL, NULL, G_CALLBACK (popup_about_cb)},
   {"TakeABreak", NULL, N_("_Take a Break"), NULL, NULL, G_CALLBACK (popup_break_cb)}
 };
 


### PR DESCRIPTION
The expected with this PR: the same icons like before

Note: I think the translations are affected, so, this is not for 1.20