### PR TITLE
theme-util.c: fix segfault on attempt to delete custom theme

### DIFF
--- a/capplets/appearance/theme-util.c
+++ b/capplets/appearance/theme-util.c
@@ -99,8 +99,8 @@ gboolean theme_delete (const gchar *name, ThemeType type)
       break;
 
     case THEME_TYPE_META:
-      theme = (MateThemeCommonInfo *) mate_theme_info_find (name);
-      theme_dir = g_strdup (theme->path);
+      theme = (MateThemeCommonInfo *) mate_theme_meta_info_find (name);
+      theme_dir = g_path_get_dirname (theme->path);
       del_empty_parent = FALSE;
       break;
 


### PR DESCRIPTION
fixes #334 
Use mate_theme_meta_info_find instead of mate_theme_info_find to find a theme (include custom theme).