### PR TITLE
Add auto-detect toggle switch

### DIFF
--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -22,34 +22,6 @@
 #include "appearance.h"
 #include "stdio.h"
 
-
-static void
-show_handlebar (AppearanceData *data, gboolean show)
-{
-  GtkWidget *handlebox = appearance_capplet_get_widget (data, "toolbar_handlebox");
-  GtkWidget *toolbar = appearance_capplet_get_widget (data, "toolbar_toolbar");
-  GtkWidget *align = appearance_capplet_get_widget (data, "toolbar_align");
-
-  g_object_ref (handlebox);
-  g_object_ref (toolbar);
-
-  if (gtk_bin_get_child (GTK_BIN (align)))
-    gtk_container_remove (GTK_CONTAINER (align), gtk_bin_get_child (GTK_BIN (align)));
-
-  if (gtk_bin_get_child (GTK_BIN (handlebox)))
-    gtk_container_remove (GTK_CONTAINER (handlebox), gtk_bin_get_child (GTK_BIN (handlebox)));
-
-  if (show) {
-    gtk_container_add (GTK_CONTAINER (align), handlebox);
-    gtk_container_add (GTK_CONTAINER (handlebox), toolbar);
-    g_object_unref (handlebox);
-  } else {
-    gtk_container_add (GTK_CONTAINER (align), toolbar);
-  }
-
-  g_object_unref (toolbar);
-}
-
 static void
 set_have_icons (AppearanceData *data, gboolean value)
 {
@@ -94,14 +66,6 @@ menus_have_icons_cb (GSettings *settings,
   set_have_icons (data, g_settings_get_boolean (settings, key));
 }
 
-static void
-toolbar_detachable_cb (GSettings *settings,
-		     gchar *key,
-		     AppearanceData *data)
-{
-  show_handlebar (data, g_settings_get_boolean (settings, key));
-}
-
 /** GUI Callbacks **/
 
 static gint
@@ -140,16 +104,4 @@ ui_init (AppearanceData *data)
   set_have_icons (data,
     g_settings_get_boolean (data->interface_settings,
 			   MENU_ICONS_KEY));
-
-  g_signal_connect (appearance_capplet_get_widget (data, "toolbar_handlebox"),
-		    "button_press_event",
-		    (GCallback) button_press_block_cb, NULL);
-
-  show_handlebar (data,
-    g_settings_get_boolean (data->interface_settings,
-			   TOOLBAR_DETACHABLE_KEY));
-
-  /* no ui for detachable toolbars */
-  g_signal_connect (data->interface_settings,
-			   "changed::" TOOLBAR_DETACHABLE_KEY, (GCallback) toolbar_detachable_cb, data);
 }

--- a/capplets/appearance/appearance.h
+++ b/capplets/appearance/appearance.h
@@ -47,7 +47,6 @@
 #define COLOR_SCHEME_KEY             "gtk-color-scheme"
 #define ACCEL_CHANGE_KEY             "can-change-accels"
 #define MENU_ICONS_KEY               "menus-have-icons"
-#define TOOLBAR_DETACHABLE_KEY       "toolbar-detachable"
 #define TOOLBAR_STYLE_KEY            "toolbar-style"
 #define GTK_FONT_DEFAULT_VALUE       "Sans 10"
 

--- a/capplets/appearance/data/appearance.ui
+++ b/capplets/appearance/data/appearance.ui
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.0 
+
+mate-appearance-properties - appearance properties dialog window
+Copyright (C) MATE Developers
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Author: Wolfgang Ulbrich
+
+-->
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <!-- interface-license-type gplv2 -->
@@ -56,23 +77,40 @@
             <property name="orientation">vertical</property>
             <property name="spacing">18</property>
             <child>
-              <object class="GtkAlignment" id="alignment5">
+              <object class="GtkBox" id="vbox_resolution">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="xscale">0</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">8</property>
                 <child>
-                  <object class="GtkBox" id="hbox_resolution">
+                  <object class="GtkLabel" id="label11">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">12</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">R_esolution</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">dpi_spinner</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox20">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">center</property>
+                    <property name="spacing">8</property>
                     <child>
-                      <object class="GtkLabel" id="label11">
+                      <object class="GtkLabel" id="label16">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">R_esolution:</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">dpi_spinner</property>
+                        <property name="label" translatable="yes">Dots per inch (DPI):</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -81,34 +119,10 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox20">
+                      <object class="GtkSpinButton" id="dpi_spinner">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkSpinButton" id="dpi_spinner">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="climb_rate">1</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label16">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">dots per inch</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="climb_rate">1</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -117,11 +131,53 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox21">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">8</property>
+                    <child>
+                      <object class="GtkLabel" id="label51">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">This resets the font DPI to the auto-detected value from Xserver.</property>
+                        <property name="label" translatable="yes">Automatic detection:</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="dpi_reset_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -757,6 +813,9 @@
                 <property name="position">3</property>
               </packing>
             </child>
+            <child>
+              <placeholder/>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -769,6 +828,9 @@
     <action-widgets>
       <action-widget response="-7">button3</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
   <object class="GtkDialog" id="theme_details">
     <property name="can_focus">False</property>
@@ -1553,6 +1615,9 @@
       <action-widget response="-11">theme_help_button</action-widget>
       <action-widget response="-7">theme_close_button</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
   <object class="GtkDialog" id="theme_save_dialog">
     <property name="can_focus">False</property>
@@ -1724,6 +1789,9 @@
       <action-widget response="-6">save_dialog_cancel_button</action-widget>
       <action-widget response="-5">save_dialog_save_button</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
   <object class="GtkListStore" id="toolbar_style_liststore">
     <columns>
@@ -3085,53 +3153,47 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
-                                  <object class="GtkHandleBox" id="toolbar_handlebox">
+                                  <object class="GtkToolbar" id="toolbar_toolbar">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
+                                    <property name="toolbar_style">both-horiz</property>
                                     <child>
-                                      <object class="GtkToolbar" id="toolbar_toolbar">
+                                      <object class="GtkToolButton" id="button2">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="toolbar_style">both-horiz</property>
-                                        <child>
-                                          <object class="GtkToolButton" id="button2">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="is_important">True</property>
-                                            <property name="stock_id">gtk-new</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="homogeneous">True</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkToolButton" id="button4">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="stock_id">gtk-open</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="homogeneous">True</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkToolButton" id="save_button">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="stock_id">gtk-save</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="homogeneous">True</property>
-                                          </packing>
-                                        </child>
-                                        <style>
-                                          <class name="primary-toolbar"/>
-                                        </style>
+                                        <property name="is_important">True</property>
+                                        <property name="stock_id">gtk-new</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="homogeneous">True</property>
+                                      </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkToolButton" id="button4">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="stock_id">gtk-open</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="homogeneous">True</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToolButton" id="save_button">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="stock_id">gtk-save</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="homogeneous">True</property>
+                                      </packing>
+                                    </child>
+                                    <style>
+                                      <class name="primary-toolbar"/>
+                                    </style>
                                   </object>
                                 </child>
                               </object>
@@ -3192,5 +3254,8 @@
       <action-widget response="-11">help_button</action-widget>
       <action-widget response="-7">close_button</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
Currently if a user changes the DPI, there is no way to reset it back to the auto-detected value from Xserver (which we store as 0 in gsettings). Adding this toggle solves that issue.

I also removed a deprecated [GtkHandleBox](https://developer.gnome.org/gtk3/stable/GtkHandleBox.html) and all its associated code.