### PR TITLE
Added middle mouse button emulation switch.

### DIFF
--- a/capplets/mouse/mate-mouse-properties.c
+++ b/capplets/mouse/mate-mouse-properties.c
@@ -267,6 +267,10 @@ setup_dialog (GtkBuilder *dialog)
 	g_settings_bind (mouse_settings, "locate-pointer", WID ("locate_pointer_toggle"),
 		"active", G_SETTINGS_BIND_DEFAULT);
 
+	/* Middle Button Emulation */
+	g_settings_bind (mouse_settings, "middle-button-enabled", WID ("middle_button_emulation_toggle"),
+		"active", G_SETTINGS_BIND_DEFAULT);
+
 	/* Double-click time */
 	g_settings_bind (mouse_settings, DOUBLE_CLICK_KEY,
 		gtk_range_get_adjustment (GTK_RANGE (WID ("delay_scale"))), "value",

--- a/capplets/mouse/mate-mouse-properties.ui
+++ b/capplets/mouse/mate-mouse-properties.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <!-- interface-license-type gplv2 -->
@@ -57,6 +57,9 @@
     <property name="default_width">500</property>
     <property name="default_height">550</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -221,7 +224,7 @@
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Locate Pointer</property>
+                        <property name="label" translatable="yes">General</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -256,6 +259,33 @@
                         <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment" id="alignment19">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="top_padding">6</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkCheckButton" id="middle_button_emulation_toggle">
+                            <property name="label" translatable="yes">Enable middle mouse button emulation through
+simultaneous left and right button click.</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                            <property name="halign">start</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>

--- a/capplets/mouse/mate-mouse-properties.ui
+++ b/capplets/mouse/mate-mouse-properties.ui
@@ -269,8 +269,7 @@
                         <property name="left_padding">12</property>
                         <child>
                           <object class="GtkCheckButton" id="middle_button_emulation_toggle">
-                            <property name="label" translatable="yes">Enable middle mouse button emulation through
-simultaneous left and right button click.</property>
+                            <property name="label" translatable="yes">Emulate middle button through simultaneous left and right click</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>


### PR DESCRIPTION
Requested in https://github.com/mate-desktop/mate-applets/issues/261

Added a toggle into the Mouse widget that handles https://github.com/mate-desktop/mate-desktop/blob/master/schemas/org.mate.peripherals-mouse.gschema.xml.in#L28:
`Enables middle mouse button emulation through simultaneous left and right button click.`

<sub> Forgive me if there's anything wrong, please, it's my first contribution to such project. :]</sub>