### PR TITLE
capplets/appearance: add buttons-have-icons switch

### DIFF
--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -25,55 +25,57 @@
 static void
 set_have_icons (AppearanceData *data, gboolean value)
 {
-  static const char *menu_item_names[] = {
-    "menu_item_1",
-    "menu_item_2",
-    "menu_item_3",
-    "menu_item_4",
-    "menu_item_5",
-    "cut",
-    "copy",
-    "paste",
-    NULL
-  };
+    static const char *menu_item_names[] = {
+        "menu_item_1",
+        "menu_item_2",
+        "menu_item_3",
+        "menu_item_4",
+        "menu_item_5",
+        "cut",
+        "copy",
+        "paste",
+        NULL
+    };
 
-  const char **name;
+    const char **name;
 
-  for (name = menu_item_names; *name != NULL; name++) {
-    GtkImageMenuItem *item = GTK_IMAGE_MENU_ITEM (appearance_capplet_get_widget (data, *name));
-    GtkWidget *image;
+    for (name = menu_item_names; *name != NULL; name++) {
+        GtkImageMenuItem *item = GTK_IMAGE_MENU_ITEM (appearance_capplet_get_widget (data, *name));
+        GtkWidget *image;
 
-    if (value) {
-      image = g_object_get_data (G_OBJECT (item), "image");
-      if (image) {
-	gtk_image_menu_item_set_image (item, image);
-	g_object_unref (image);
-      }
-    } else {
-      image = gtk_image_menu_item_get_image (item);
-      g_object_set_data (G_OBJECT (item), "image", image);
-      g_object_ref (image);
-      gtk_image_menu_item_set_image (item, NULL);
+        if (value) {
+            image = g_object_get_data (G_OBJECT (item), "image");
+            if (image) {
+                gtk_image_menu_item_set_image (item, image);
+                g_object_unref (image);
+            }
+        }
+        else
+        {
+            image = gtk_image_menu_item_get_image (item);
+            g_object_set_data (G_OBJECT (item), "image", image);
+            g_object_ref (image);
+            gtk_image_menu_item_set_image (item, NULL);
+        }
     }
-  }
 }
 
 static void
 menus_have_icons_cb (GSettings *settings,
-		     gchar *key,
-		     AppearanceData      *data)
+                     gchar *key,
+                     AppearanceData      *data)
 {
-  set_have_icons (data, g_settings_get_boolean (settings, key));
+    set_have_icons (data, g_settings_get_boolean (settings, key));
 }
 
 /** GUI Callbacks **/
 
 static gint
 button_press_block_cb (GtkWidget *toolbar,
-		       GdkEvent  *event,
-		       gpointer   data)
+                       GdkEvent  *event,
+                       gpointer   data)
 {
-  return TRUE;
+    return TRUE;
 }
 
 /** Public Functions **/
@@ -81,34 +83,34 @@ button_press_block_cb (GtkWidget *toolbar,
 void
 ui_init (AppearanceData *data)
 {
-  GtkWidget* widget;
+    GtkWidget* widget;
 
-  /* FIXME maybe just remove that stuff from .ui file */
-  GtkWidget* container = appearance_capplet_get_widget(data, "vbox24");
+    /* FIXME maybe just remove that stuff from .ui file */
+    GtkWidget* container = appearance_capplet_get_widget(data, "vbox24");
 
-  // Remove menu accels and toolbar style toggles for new GTK versions
-  gtk_container_remove((GtkContainer *) container,
-			 appearance_capplet_get_widget(data, "menu_accel_toggle"));
-  gtk_container_remove((GtkContainer *) container,
-			 appearance_capplet_get_widget(data, "hbox11"));
+    // Remove menu accels and toolbar style toggles for new GTK versions
+    gtk_container_remove((GtkContainer *) container,
+    appearance_capplet_get_widget(data, "menu_accel_toggle"));
+    gtk_container_remove((GtkContainer *) container,
+    appearance_capplet_get_widget(data, "hbox11"));
 
-  widget = appearance_capplet_get_widget(data, "menu_icons_toggle");
-	g_settings_bind (data->interface_settings,
-			 MENU_ICONS_KEY,
-			 G_OBJECT (widget),
-			 "active",
-			 G_SETTINGS_BIND_DEFAULT);
-  g_signal_connect (data->interface_settings, "changed::" MENU_ICONS_KEY,
-                      G_CALLBACK (menus_have_icons_cb), data);
+    widget = appearance_capplet_get_widget(data, "menu_icons_toggle");
+    g_settings_bind (data->interface_settings,
+                     MENU_ICONS_KEY,
+                     G_OBJECT (widget),
+                     "active",
+                     G_SETTINGS_BIND_DEFAULT);
+    g_signal_connect (data->interface_settings, "changed::" MENU_ICONS_KEY,
+    G_CALLBACK (menus_have_icons_cb), data);
 
-  set_have_icons (data,
-    g_settings_get_boolean (data->interface_settings,
-			   MENU_ICONS_KEY));
+    set_have_icons (data,
+                    g_settings_get_boolean (data->interface_settings,
+                                            MENU_ICONS_KEY));
 
-  widget = appearance_capplet_get_widget(data, "button_icons_toggle");
-  g_settings_bind (data->interface_settings,
-     BUTTON_ICONS_KEY,
-     G_OBJECT (widget),
-     "active",
-     G_SETTINGS_BIND_DEFAULT);
+    widget = appearance_capplet_get_widget(data, "button_icons_toggle");
+    g_settings_bind (data->interface_settings,
+                     BUTTON_ICONS_KEY,
+                     G_OBJECT (widget),
+                     "active",
+                     G_SETTINGS_BIND_DEFAULT);
 }

--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -104,4 +104,11 @@ ui_init (AppearanceData *data)
   set_have_icons (data,
     g_settings_get_boolean (data->interface_settings,
 			   MENU_ICONS_KEY));
+
+  widget = appearance_capplet_get_widget(data, "button_icons_toggle");
+  g_settings_bind (data->interface_settings,
+     BUTTON_ICONS_KEY,
+     G_OBJECT (widget),
+     "active",
+     G_SETTINGS_BIND_DEFAULT);
 }

--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -90,9 +90,9 @@ ui_init (AppearanceData *data)
 
     // Remove menu accels and toolbar style toggles for new GTK versions
     gtk_container_remove((GtkContainer *) container,
-    appearance_capplet_get_widget(data, "menu_accel_toggle"));
+                         appearance_capplet_get_widget(data, "menu_accel_toggle"));
     gtk_container_remove((GtkContainer *) container,
-    appearance_capplet_get_widget(data, "hbox11"));
+                         appearance_capplet_get_widget(data, "hbox11"));
 
     widget = appearance_capplet_get_widget(data, "menu_icons_toggle");
     g_settings_bind (data->interface_settings,
@@ -101,7 +101,7 @@ ui_init (AppearanceData *data)
                      "active",
                      G_SETTINGS_BIND_DEFAULT);
     g_signal_connect (data->interface_settings, "changed::" MENU_ICONS_KEY,
-    G_CALLBACK (menus_have_icons_cb), data);
+                      G_CALLBACK (menus_have_icons_cb), data);
 
     set_have_icons (data,
                     g_settings_get_boolean (data->interface_settings,

--- a/capplets/appearance/appearance.h
+++ b/capplets/appearance/appearance.h
@@ -47,6 +47,7 @@
 #define COLOR_SCHEME_KEY             "gtk-color-scheme"
 #define ACCEL_CHANGE_KEY             "can-change-accels"
 #define MENU_ICONS_KEY               "menus-have-icons"
+#define BUTTON_ICONS_KEY             "buttons-have-icons"
 #define TOOLBAR_STYLE_KEY            "toolbar-style"
 #define GTK_FONT_DEFAULT_VALUE       "Sans 10"
 

--- a/capplets/appearance/data/appearance.ui
+++ b/capplets/appearance/data/appearance.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 
+<!-- Generated with glade 3.22.1 
 
 mate-appearance-properties - appearance properties dialog window
 Copyright (C) MATE Developers
@@ -35,6 +35,9 @@ Author: Wolfgang Ulbrich
     <property name="title" translatable="yes">Font Rendering Details</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -828,9 +831,6 @@ Author: Wolfgang Ulbrich
     <action-widgets>
       <action-widget response="-7">button3</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkDialog" id="theme_details">
     <property name="can_focus">False</property>
@@ -840,6 +840,9 @@ Author: Wolfgang Ulbrich
     <property name="window_position">center-on-parent</property>
     <property name="default_height">450</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox4">
         <property name="visible">True</property>
@@ -1615,9 +1618,6 @@ Author: Wolfgang Ulbrich
       <action-widget response="-11">theme_help_button</action-widget>
       <action-widget response="-7">theme_close_button</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkDialog" id="theme_save_dialog">
     <property name="can_focus">False</property>
@@ -1625,6 +1625,9 @@ Author: Wolfgang Ulbrich
     <property name="title" translatable="yes">Save Theme As...</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
@@ -1789,9 +1792,6 @@ Author: Wolfgang Ulbrich
       <action-widget response="-6">save_dialog_cancel_button</action-widget>
       <action-widget response="-5">save_dialog_save_button</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkListStore" id="toolbar_style_liststore">
     <columns>
@@ -1864,6 +1864,9 @@ Author: Wolfgang Ulbrich
     <property name="default_width">790</property>
     <property name="default_height">560</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
@@ -2985,6 +2988,76 @@ Author: Wolfgang Ulbrich
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox" id="vbox28">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label52">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Buttons</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox14">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="label53">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label">    </property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="button_icons_toggle">
+                            <property name="label" translatable="yes">Show icons on buttons</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="tooltip_text" translatable="yes">Whether buttons may display an icon in addition to the button text</property>
+                            <property name="halign">start</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox" id="vbox25">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -3221,7 +3294,7 @@ Author: Wolfgang Ulbrich
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -3254,8 +3327,5 @@ Author: Wolfgang Ulbrich
       <action-widget response="-11">help_button</action-widget>
       <action-widget response="-7">close_button</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>


### PR DESCRIPTION
Requested in https://github.com/mate-desktop/mate-control-center/issues/346

Handles `org.mate.interface buttons-have-icons`