### PR TITLE
Fixed image size

### DIFF
--- a/capplets/about-me/e-image-chooser.h
+++ b/capplets/about-me/e-image-chooser.h
@@ -23,9 +23,7 @@
 
 #include <gtk/gtk.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 #define E_TYPE_IMAGE_CHOOSER	        (e_image_chooser_get_type ())
 #define E_IMAGE_CHOOSER(obj)	        (G_TYPE_CHECK_INSTANCE_CAST ((obj), E_TYPE_IMAGE_CHOOSER, EImageChooser))
@@ -35,13 +33,10 @@ extern "C" {
 
 typedef struct _EImageChooser        EImageChooser;
 typedef struct _EImageChooserClass   EImageChooserClass;
-typedef struct _EImageChooserPrivate EImageChooserPrivate;
 
 struct _EImageChooser
 {
 	GtkBox parent;
-
-	EImageChooserPrivate *priv;
 };
 
 struct _EImageChooserClass
@@ -54,17 +49,17 @@ struct _EImageChooserClass
 
 };
 
-GtkWidget *e_image_chooser_new      (void);
-GType      e_image_chooser_get_type (void);
+GtkWidget *e_image_chooser_new            (void);
+GtkWidget *e_image_chooser_new_with_size  (int width, int height);
+GType      e_image_chooser_get_type       (void);
 
 gboolean   e_image_chooser_set_from_file  (EImageChooser *chooser, const char *filename);
 gboolean   e_image_chooser_set_image_data (EImageChooser *chooser, char *data, gsize data_length);
 void       e_image_chooser_set_editable   (EImageChooser *chooser, gboolean editable);
+void       e_image_chooser_set_scaleable  (EImageChooser *chooser, gboolean scaleable);
 
 gboolean   e_image_chooser_get_image_data (EImageChooser *chooser, char **data, gsize *data_length);
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS
 
 #endif /* _E_IMAGE_CHOOSER_H_ */

--- a/capplets/about-me/mate-about-me.c
+++ b/capplets/about-me/mate-about-me.c
@@ -438,7 +438,7 @@ about_me_setup_dialog (void)
 	dialog = gtk_builder_new ();
 	gtk_builder_add_from_file (dialog, MATECC_UI_DIR "/mate-about-me-dialog.ui", NULL);
 
-	me->image_chooser = e_image_chooser_new ();
+	me->image_chooser = e_image_chooser_new_with_size (MAX_WIDTH, MAX_HEIGHT);
 	gtk_container_add (GTK_CONTAINER (WID ("button-image")), me->image_chooser);
 
 	if (dialog == NULL) {


### PR DESCRIPTION
Fixed EImageChooser's bug for mate-about-me, now it show fixed size image.

This bug can be found through testing:

For example, if you set different images one after another as user face, even if these images have the same size, they will still cause the displayed images to grow larger.

The follow image use the same file /usr/share/pixmaps/faces/book.jpg, but after change the user face  many times, it will show lager:
![2018-09-03 10-34-29](https://user-images.githubusercontent.com/665058/44964918-9455aa80-af65-11e8-9e10-de675500e9a9.png)

![2018-09-03 10-35-07](https://user-images.githubusercontent.com/665058/44964932-a20b3000-af65-11e8-808d-e40582ee5233.png)

On the mate-about-me dialog, I think we should always show a fixed size picture.