### PR TITLE
keybindings: Add a key binding to launch settings

### DIFF
--- a/capplets/keybindings/01-desktop-key.xml.in
+++ b/capplets/keybindings/01-desktop-key.xml.in
@@ -19,5 +19,7 @@
 
 	<KeyListEntry name="search" description="Search" />
 
+	<KeyListEntry name="control-center" description="Launch settings"/>
+
 </KeyListEntries>
 


### PR DESCRIPTION
Provided additional "control-center" key binding.

For reference: https://github.com/mate-desktop/mate-settings-daemon/pull/244
