### PR TITLE
mate-keybinding-properties: avoid deprecated 'gtk_widget_ensure_style'

### DIFF
--- a/capplets/keybindings/mate-keybinding-properties.c
+++ b/capplets/keybindings/mate-keybinding-properties.c
@@ -536,7 +536,6 @@ ensure_scrollbar (GtkBuilder *builder, int i)
                                                          "actions_swindow");
       GtkWidget *treeview = _gtk_builder_get_widget (builder,
                                                      "shortcut_treeview");
-      gtk_widget_ensure_style (treeview);
       gtk_widget_get_preferred_size (treeview, &rectangle, NULL);
       gtk_widget_set_size_request (treeview, -1, rectangle.height);
       gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (actions_swindow),


### PR DESCRIPTION
Seems `gtk_widget_ensure_style` is useless, according to the documentation:

https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-ensure-style

> Not a very useful function; most of the time, if you want the style, the widget is realized, and realized widgets are guaranteed to have a style already.