### PR TITLE
default-applications: Use the selected word processor for RTF as well

### DIFF
--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -132,6 +132,7 @@ set_changed(GtkComboBox* combo, MateDACapplet* capplet, GList* list, gint type)
 
 			case DA_TYPE_WORD:
 				g_app_info_set_as_default_for_type(item, "application/vnd.oasis.opendocument.text", NULL);
+				g_app_info_set_as_default_for_type(item, "application/rtf", NULL);
 				g_app_info_set_as_default_for_type(item, "application/msword", NULL);
 				g_app_info_set_as_default_for_type(item, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", NULL);
 				break;


### PR DESCRIPTION
RTF files should be handled by the preferred word processor, just like ODF, DOC and OOXML.