### PR TITLE
default-applications: Add a widget for a default calculator application

### DIFF
--- a/capplets/default-applications/mate-da-capplet.h
+++ b/capplets/default-applications/mate-da-capplet.h
@@ -35,6 +35,9 @@
 #define MOBILITY_KEY          "exec"
 #define MOBILITY_STARTUP_KEY  "startup"
 
+#define CALCULATOR_SCHEMA     "org.mate.applications-calculator"
+#define CALCULATOR_KEY        "exec"
+
 typedef struct _MateDACapplet {
 	GtkBuilder* builder;
 
@@ -55,6 +58,7 @@ typedef struct _MateDACapplet {
 	GtkWidget* document_combo_box;
 	GtkWidget* word_combo_box;
 	GtkWidget* spreadsheet_combo_box;
+	GtkWidget* calculator_combo_box;
 
 	/* Visual Accessibility */
 	GtkWidget* visual_startup_checkbutton;
@@ -76,11 +80,13 @@ typedef struct _MateDACapplet {
 	GList* document_viewers;
 	GList* word_editors;
 	GList* spreadsheet_editors;
+	GList* calculators;
 
 	/* Settings objects */
 	GSettings* terminal_settings;
 	GSettings* visual_settings;
 	GSettings* mobility_settings;
+	GSettings* calculator_settings;
 } MateDACapplet;
 
 #endif

--- a/capplets/default-applications/mate-default-applications-properties.ui
+++ b/capplets/default-applications/mate-default-applications-properties.ui
@@ -863,6 +863,83 @@
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="calculator_vbox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="calculator_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Calculator</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="calculator_hbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkImage" id="calculator_image">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">start</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="calculator_options_vbox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkComboBox" id="calculator_combobox">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="position">2</property>


### PR DESCRIPTION
• Exposes a widget in Preferred Applications to control the default calculator application schema defined in commit https://github.com/mate-desktop/mate-desktop/pull/341/commits/328116089489c674bad3b17bc69c267865968d24
• In order to function properly, this PR is dependent on the merger of these two PRs:
1. https://github.com/mate-desktop/mate-desktop/pull/341
2. https://github.com/mate-desktop/mate-settings-daemon/pull/255

• Also fix https://github.com/mate-desktop/mate-control-center/issues/291