### PR TITLE
default-applications: Use more common icon names for Office documents

### DIFF
--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -335,8 +335,8 @@ static struct {
 	{"text_image",         "text-editor"},
 	{"terminal_image",     "terminal"},
 	{"document_image",     "application-pdf"},
-	{"word_image",         "office-document"},
-	{"spreadsheet_image",  "office-spreadsheet"},
+	{"word_image",         "x-office-document"},
+	{"spreadsheet_image",  "x-office-spreadsheet"},
 	{"calculator_image",   "accessories-calculator"},
 };
 


### PR DESCRIPTION
_"x-office-document"_ and _"x-office-spreadsheet"_ are more common MIME icon names than their counterparts without the _"x-"_ prefix.
The latter seems not to even be available in _"MATE"_ icon theme, but only in _"Faenza"_ icon theme.  The _"x-"_-prefixed variant on the other hand is available even in theme providing the unprefixed ones, meaning it will sill work with these.

On my machine with not many themes, but only standard-ish ones:
```console
$ find /usr/share/icons/ -name office-document.* | wc -l
8
$ find /usr/share/icons/ -name x-office-document.* | wc -l
54
```

Thus, using the prefixed variant seems like a better choice.