### PR TITLE
control-center: Fix memory leak

### DIFF
--- a/libslab/app-shell.h
+++ b/libslab/app-shell.h
@@ -112,7 +112,7 @@ typedef struct
 
 typedef struct
 {
-	const gchar *name;
+	gchar *name;
 	MateDesktopItem *item;
 } AppAction;
 

--- a/shell/control-center.c
+++ b/shell/control-center.c
@@ -70,6 +70,8 @@ static GSList* get_actions_list(void)
 
 		if ((action->item = load_desktop_item_from_unknown(temp[1])) == NULL)
 		{
+			g_free (action->name);
+			g_free (action);
 			g_warning("get_actions_list() - PROBLEM - Can't load %s\n", temp[1]);
 		}
 		else


### PR DESCRIPTION
Reported by clang:

  control-center.c:84:2: warning: Potential leak of memory pointed to by 'action'
          g_slist_free(key_list);
          ^~~~~~~~~~~~