### PR TITLE
Remove dead store detected by clang

### DIFF
--- a/capplets/appearance/appearance-themes.c
+++ b/capplets/appearance/appearance-themes.c
@@ -802,7 +802,7 @@ static void
 theme_install_cb (GtkWidget *button, AppearanceData *data)
 {
   mate_theme_installer_run (
-      GTK_WINDOW (appearance_capplet_get_widget (data, "appearance_window")), NULL);
+      GTK_WINDOW (appearance_capplet_get_widget (data, "appearance_window")));
 }
 
 static void

--- a/capplets/appearance/theme-installer.c
+++ b/capplets/appearance/theme-installer.c
@@ -796,8 +796,7 @@ mate_theme_install (GFile *file,
 }
 
 void
-mate_theme_installer_run (GtkWindow *parent,
-			   const gchar *filename)
+mate_theme_installer_run (GtkWindow *parent)
 {
 	static gboolean running_theme_install = FALSE;
 	static gchar old_folder[512] = "";
@@ -808,9 +807,6 @@ mate_theme_installer_run (GtkWindow *parent,
 		return;
 
 	running_theme_install = TRUE;
-
-	if (filename == NULL)
-		filename = old_folder;
 
 	dialog = gtk_file_chooser_dialog_new (_("Select Theme"),
 					      parent,

--- a/capplets/appearance/theme-installer.h
+++ b/capplets/appearance/theme-installer.h
@@ -23,6 +23,6 @@
 #define THEME_INSTALLER_H
 
 void mate_theme_install (GFile *file, GtkWindow *parent);
-void mate_theme_installer_run (GtkWindow *parent, const gchar *filename);
+void mate_theme_installer_run (GtkWindow *parent);
 
 #endif /* THEME_INSTALLER_H */

--- a/libwindow-settings/marco-window-manager.c
+++ b/libwindow-settings/marco-window-manager.c
@@ -405,7 +405,6 @@ marco_get_double_click_actions (MateWindowManager              *wm,
                 int i;
                 
                 initialized = TRUE;
-                i = 0;
                 for (i = 0; i < G_N_ELEMENTS (actions); i++) {
                         actions[i].human_readable_name = _(actions[i].human_readable_name);
                 }


### PR DESCRIPTION
marco-window-manager.c:408:17: warning: Value stored to 'i' is never read
                i = 0;
                ^   ~

theme-installer.c:813:3: warning: Value stored to 'filename' is never read
                filename = old_folder;
                ^          ~~~~~~~~~~