### PR TITLE
github release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -264,12 +264,12 @@ after_scripts:
   - make distcheck
 
 releases:
-  draft: False
-  prerelease: False
-  checksum: True
-  file_glob: True
+  draft: false
+  prerelease: false
+  checksum: true
+  file_glob: true
   files: mate-control-center-*.tar.xz
   github_release:
-    tags: True
-    overwrite: True
+    tags: true
+    overwrite: true
     base_version: 1.20.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
   - curl -Ls -o gen-index https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/gen-index.sh
   - chmod +x docker-build gen-index
- 
+
 install:
   - sudo apt-get install -y python3-pip python3-setuptools
   - sudo pip3 install --upgrade pip
@@ -24,16 +24,22 @@ script:
   - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build scripts
 
 deploy:
-  provider: pages
-  github-token: $GITHUB_TOKEN
-  #keep-history: true
-  skip_cleanup: true
-  committer-from-gh: true
-  target-branch: gh-pages
-  local-dir: html-report
-  on:
-    all_branches: true
-    condition: ${DISTRO} =~ ^fedora.*$
+  - provider: pages
+    github-token: $GITHUB_TOKEN
+    #keep-history: true
+    skip_cleanup: true
+    committer-from-gh: true
+    target-branch: gh-pages
+    local-dir: html-report
+    on:
+      all_branches: true
+      condition: ${DISTRO} =~ ^fedora.*$
+  - provider: script
+    script: ./docker-build --verbose --config .travis.yml --release github
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: "${TRAVIS_TAG} =~ ^v.*$ && ${DISTRO} =~ ^fedora.*$"
 
 after_success:
   - 'if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" && "$TRAVIS_PULL_REQUEST" != "false" && ${DISTRO} =~ ^fedora.*$ ]]; then
@@ -256,3 +262,14 @@ after_scripts:
   -   ./gen-index -i https://github.com/${OWNER_NAME}/mate-icon-theme/raw/master/mate/16x16/categories/preferences-desktop.png
   - fi
   - make distcheck
+
+releases:
+  draft: False
+  prerelease: False
+  checksum: True
+  file_glob: True
+  files: mate-control-center-*.tar.xz
+  github_release:
+    tags: True
+    overwrite: True
+    base_version: 1.20.0


### PR DESCRIPTION
Let's try to release tarballs on github.

Here is the step:

1. change `.travis.yml`, add new section named `deploy` like this:
```
deploy:
    provider: script
    script: ./docker-build --verbose --config .travis.yml --release github
    skip_cleanup: true
    on:
      tags: true
      condition: "${TRAVIS_TAG} =~ ^v.*$ && ${DISTRO} =~ ^fedora.*$"
```
If there already has some `provider` in `deploy` section, just added new provider like this PR does.

2. change `.travis.yml`, add `release` section for `docker-build` to generate chesum files.
```
releases:
  draft: false
  prerelease: false
  checksum: true                             # true, means to create checksum file.
  file_glob: true
  files: mate-control-center-*.tar.xz   # NOTE HERE, match the tarballs.
  github_release:
    tags: true
    overwrite: true
    base_version: 1.20.0
```

3. open the https://travis-ci.org website, create hidden variables named `GITHUB_TOKEN`, so travis can upload the tarballs to github.
There are some repos I have created this variable, so it don't have to do anything.

4. use the `git push origin v1.22.0` to push the tag to github to trigger travis work.

If the `v1.22.0` tag already exists on github, delete the remote tag and re-push the tag to trigger travis works.
```
git push origin :v1.22.0
git push origin v1.22.0
```

Maybe this PR should merged into master first.