### PR TITLE
Use GtkSeparatorMenuItem in Apparence preview

### DIFF
--- a/capplets/appearance/data/appearance.ui
+++ b/capplets/appearance/data/appearance.ui
@@ -3141,7 +3141,7 @@ Author: Wolfgang Ulbrich
                                           </object>
                                         </child>
                                         <child>
-                                          <object class="GtkMenuItem" id="separator1">
+                                          <object class="GtkSeparatorMenuItem" id="separator1">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                           </object>
@@ -3156,7 +3156,7 @@ Author: Wolfgang Ulbrich
                                           </object>
                                         </child>
                                         <child>
-                                          <object class="GtkMenuItem" id="separator2">
+                                          <object class="GtkSeparatorMenuItem" id="separator2">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                           </object>


### PR DESCRIPTION
It adds two menu item separators, before and after of Print menu item.

Test:
- Run mate-appearance-properties
- Select Interface tab
- Click on File menu item

Before:

![menu-before](https://user-images.githubusercontent.com/10171411/55801482-7e4d3100-5ad6-11e9-8c72-6de46b0a5b69.png)

After:

![menu-after](https://user-images.githubusercontent.com/10171411/55801498-85743f00-5ad6-11e9-917d-88bbbb63b212.png)
