### PR TITLE
Revert icon-name for imageviewer_image

### DIFF
--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -331,7 +331,7 @@ static struct {
 	{"mobility_image",     "preferences-desktop-accessibility"},
 	{"messenger_image",    "user-idle"},
 	{"filemanager_image",  "file-manager"},
-	{"imageviewer_image",  "eom"},
+	{"imageviewer_image",  "image-x-generic"},
 	{"video_image",        "video-x-generic"},
 	{"text_image",         "text-editor"},
 	{"terminal_image",     "terminal"},


### PR DESCRIPTION
The icon-name should be "image-x-generic" (imageviewer_image),
like "audio-x-generic" (media_player_image) and "video-x-generic"
(video_image).

Those icons (imageviewer_image, media_player_image,
video_image) are the generic mime types which can be opened
using its preferred application.

Before:

![Captura de pantalla a 2019-06-07 23-54-41](https://user-images.githubusercontent.com/10171411/59135628-fd989d00-897f-11e9-895e-78fd251c2215.png)

After:

![Captura de pantalla a 2019-06-08 09-24-36](https://user-images.githubusercontent.com/10171411/59143810-504d7580-89cf-11e9-8103-5a141a189a53.png)
