### PR TITLE
drop libXxf86 dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,13 +124,6 @@ dnl keyboard-properties-capplet
 savecppflags=$CPPFLAGS
 CPPFLAGS="$CPPFLAGS $X_CFLAGS"
 AC_CHECK_HEADERS([X11/Xlib.h])
-AC_CHECK_LIB(Xxf86misc, XF86MiscQueryExtension, [
-  AC_CHECK_HEADERS([X11/extensions/xf86misc.h], [XF86MISC_LIBS="-lXxf86misc"],[],
-[#if HAVE_X11_XLIB_H
-#include <X11/Xlib.h>
-#endif
-])])
-AC_SUBST(XF86MISC_LIBS)
 AC_CHECK_HEADERS(X11/extensions/XKB.h)
 CPPFLAGS=$savecppflags
 


### PR DESCRIPTION
The X server hasn't implemented it in over 10 years.
and it was dropped from debian since a long time.

fixes https://github.com/mate-desktop/mate-control-center/issues/481