### PR TITLE
font-viewer: Add font/ttf and font/otf mime types

### DIFF
--- a/font-viewer/mate-font-viewer.thumbnailer
+++ b/font-viewer/mate-font-viewer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=mate-thumbnail-font
 Exec=mate-thumbnail-font --size %s %u %o
-MimeType=application/x-font-ttf;application/x-font-type1;application/x-font-pcf;application/x-font-otf
+MimeType=application/x-font-ttf;application/x-font-type1;application/x-font-pcf;application/x-font-otf;font/ttf;font/otf


### PR DESCRIPTION
shared-mime-info 1.9 and newer use font/ttf and font/otf as the mime types for OpenType and TrueType fonts.

This fixes font thumbnailing on Debian Buster, Ubuntu Bionic, Mint Tara and newer versions.
GNOME has a similar update.