### PR TITLE
remove warning: "__sun" is not defined, evaluates to 0

### DIFF
--- a/capplets/about-me/mate-about-me-password.c
+++ b/capplets/about-me/mate-about-me-password.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#if __sun
+#ifdef __sun
 #include <sys/types.h>
 #include <signal.h>
 #endif


### PR DESCRIPTION
```
mate-about-me-password.c:39:5: warning: "__sun" is not defined, evaluates to 0 [-Wundef]
   39 | #if __sun
      |     ^~~~~
```