### PR TITLE
fv: thumbnailer: add font/collection to the supported mimetypes

### DIFF
--- a/font-viewer/mate-font-viewer.thumbnailer
+++ b/font-viewer/mate-font-viewer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=mate-thumbnail-font
 Exec=mate-thumbnail-font --size %s %u %o
-MimeType=application/x-font-ttf;application/x-font-type1;application/x-font-pcf;application/x-font-otf;font/ttf;font/otf
+MimeType=application/x-font-ttf;application/x-font-type1;application/x-font-pcf;application/x-font-otf;font/ttf;font/otf;font/collection;


### PR DESCRIPTION
We support collections but don't advertise the mimetype, so we fail
to lookup the correct thumbnailer.

origin commit:
https://gitlab.gnome.org/GNOME/gnome-font-viewer/commit/e1c54dd

This fixes creating thumbnail for e.g. google-noto-cjk fonts and warnings like this.
```
(mate-font-viewer:10706): MateDesktop-WARNING **: 15:59:02.209: Error creating thumbnail for file:///usr/share/fonts/google-noto-cjk/NotoSansCJK-Thin.ttc: Unrecognized image file format

(mate-font-viewer:10706): MateDesktop-WARNING **: 15:59:02.210: Unable to create loader for mime type font/collection: Unrecognized image file format

etc....
```