### PR TITLE
shell: Fix typo in keyword name

### DIFF
--- a/shell/matecc.desktop.in
+++ b/shell/matecc.desktop.in
@@ -10,5 +10,5 @@ Type=Application
 StartupNotify=false
 Categories=GTK;Settings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Keywords=MATE;control;center;configuration;tool;destop;preferences;
+Keywords=MATE;control;center;configuration;tool;desktop;preferences;
 OnlyShowIn=MATE;


### PR DESCRIPTION
Closes https://github.com/mate-desktop/mate-control-center/issues/512