### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/capplets/about-me/e-image-chooser.c
+++ b/capplets/about-me/e-image-chooser.c
@@ -57,8 +57,7 @@ enum {
 
 static GParamSpec *properties[NUM_PROPERTIES] = { NULL, };
 static guint image_chooser_signals [LAST_SIGNAL] = { 0 };
-static void e_image_chooser_init	 (EImageChooser		 *chooser);
-static void e_image_chooser_class_init	 (EImageChooserClass	 *klass);
+
 static void e_image_chooser_dispose      (GObject *object);
 
 static gboolean image_drag_motion_cb (GtkWidget *widget,

--- a/libslab/app-resizer.c
+++ b/libslab/app-resizer.c
@@ -23,8 +23,6 @@
 #include "app-shell.h"
 #include "app-resizer.h"
 
-static void app_resizer_class_init (AppResizerClass *);
-static void app_resizer_init (AppResizer *);
 static void app_resizer_size_allocate (GtkWidget * resizer, GtkAllocation * allocation);
 static gboolean app_resizer_paint_window (GtkWidget * widget, cairo_t * cr, AppShellData * app_data);
 

--- a/libslab/nameplate-tile.c
+++ b/libslab/nameplate-tile.c
@@ -20,8 +20,6 @@
 
 #include "nameplate-tile.h"
 
-static void nameplate_tile_class_init (NameplateTileClass *);
-static void nameplate_tile_init (NameplateTile *);
 static void nameplate_tile_get_property (GObject *, guint, GValue *, GParamSpec *);
 static void nameplate_tile_set_property (GObject *, guint, const GValue *, GParamSpec *);
 static GObject *nameplate_tile_constructor (GType, guint, GObjectConstructParam *);

--- a/libslab/search-bar.c
+++ b/libslab/search-bar.c
@@ -37,8 +37,6 @@ typedef struct
 	gboolean block_signal;
 } NldSearchBarPrivate;
 
-static void nld_search_bar_class_init (NldSearchBarClass *);
-static void nld_search_bar_init (NldSearchBar *);
 static void nld_search_bar_finalize (GObject *);
 
 static gboolean nld_search_bar_focus (GtkWidget *, GtkDirectionType);

--- a/libslab/shell-window.c
+++ b/libslab/shell-window.c
@@ -25,8 +25,6 @@
 
 #include "app-resizer.h"
 
-static void shell_window_class_init (ShellWindowClass *);
-static void shell_window_init (ShellWindow *);
 static void shell_window_handle_size_request (GtkWidget * widget, GtkRequisition * requisition,
 	AppShellData * data);
 

--- a/libslab/themed-icon.c
+++ b/libslab/themed-icon.c
@@ -22,8 +22,6 @@
 
 #include "mate-utils.h"
 
-static void themed_icon_class_init (ThemedIconClass *);
-static void themed_icon_init (ThemedIcon *);
 static void themed_icon_finalize (GObject *);
 static void themed_icon_get_property (GObject *, guint, GValue *, GParamSpec *);
 static void themed_icon_set_property (GObject *, guint, const GValue *, GParamSpec *);

--- a/typing-break/drw-break-window.c
+++ b/typing-break/drw-break-window.c
@@ -64,8 +64,6 @@ enum {
 	LAST_SIGNAL
 };
 
-static void         drw_break_window_class_init    (DrwBreakWindowClass *klass);
-static void         drw_break_window_init          (DrwBreakWindow      *window);
 static void         drw_break_window_finalize      (GObject             *object);
 static void         drw_break_window_dispose       (GObject             *object);
 static gboolean     postpone_sensitize_cb          (DrwBreakWindow      *window);


### PR DESCRIPTION
Fixes the warnings:

```
e-image-chooser.c:76:44: warning: redundant redeclaration of ‘e_image_chooser_init’ [-Wredundant-decls]
e-image-chooser.c:76:44: warning: redundant redeclaration of ‘e_image_chooser_class_init’ [-Wredundant-decls]
app-resizer.c:31:28: warning: redundant redeclaration of ‘app_resizer_init’ [-Wredundant-decls]
app-resizer.c:31:28: warning: redundant redeclaration of ‘app_resizer_class_init’ [-Wredundant-decls]
nameplate-tile.c:48:44: warning: redundant redeclaration of ‘nameplate_tile_init’ [-Wredundant-decls]
nameplate-tile.c:48:44: warning: redundant redeclaration of ‘nameplate_tile_class_init’ [-Wredundant-decls]
search-bar.c:55:43: warning: redundant redeclaration of ‘nld_search_bar_init’ [-Wredundant-decls]
search-bar.c:55:43: warning: redundant redeclaration of ‘nld_search_bar_class_init’ [-Wredundant-decls]
shell-window.c:37:29: warning: redundant redeclaration of ‘shell_window_init’ [-Wredundant-decls]
shell-window.c:37:29: warning: redundant redeclaration of ‘shell_window_class_init’ [-Wredundant-decls]
themed-icon.c:46:41: warning: redundant redeclaration of ‘themed_icon_init’ [-Wredundant-decls]
themed-icon.c:46:41: warning: redundant redeclaration of ‘themed_icon_class_init’ [-Wredundant-decls]
drw-break-window.c:82:45: warning: redundant redeclaration of ‘drw_break_window_init’ [-Wredundant-decls]
drw-break-window.c:82:45: warning: redundant redeclaration of ‘drw_break_window_class_init’ [-Wredundant-decls]
```