### PR TITLE
keybindings: Fix schema creation in makefile

### DIFF
--- a/capplets/keybindings/Makefile.am
+++ b/capplets/keybindings/Makefile.am
@@ -29,7 +29,7 @@ xmldir = $(pkgdatadir)/keybindings
 xml_in_files = 00-multimedia-key.xml.in 01-desktop-key.xml.in
 xml_DATA = $(xml_in_files:.xml.in=.xml)
 
-$(xml_DATA): $(xml_in_files)
+%.xml: %.xml.in
 	$(AM_V_GEN) GETTEXTDATADIR=$(top_srcdir) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = mate-keybindings.pc


### PR DESCRIPTION
This fixes the contents of the first schema file getting copied into the second.

This is a similar issue as I just fixed in https://github.com/mate-desktop/mate-control-center/commit/2aa9de5d86ceb7e21cecfe79d4c85626f2538c98 - might be worth for you guys to review all the makefiles touched in the gettext transition.