### PR TITLE
Look for system themes in system data dirs

### DIFF
--- a/capplets/common/gtkrc-utils.c
+++ b/capplets/common/gtkrc-utils.c
@@ -60,15 +60,19 @@ gchar* gtkrc_find_named(const gchar* name)
 
 	if (!path)
 	{
-		gchar* theme_dir = gtk_rc_get_theme_dir();
-		path = g_build_filename(theme_dir, name, subpath, NULL);
-		g_free(theme_dir);
+		const gchar * const * dirs = g_get_system_data_dirs();
 
-		if (!g_file_test(path, G_FILE_TEST_EXISTS))
-		{
-			g_free (path);
-			path = NULL;
-		}
+		if (dirs != NULL)
+			for (; !path && *dirs != NULL; ++dirs)
+			{
+				path = g_build_filename(*dirs, "themes", name, subpath, NULL);
+
+				if (!g_file_test(path, G_FILE_TEST_EXISTS))
+				{
+					g_free (path);
+					path = NULL;
+				}
+			}
 	}
 
 	return path;

--- a/capplets/common/mate-theme-info.c
+++ b/capplets/common/mate-theme-info.c
@@ -1763,6 +1763,7 @@ mate_theme_color_scheme_equal (const gchar *s1, const gchar *s2)
 void
 mate_theme_init ()
 {
+  const gchar * const * dirs;
   GFile *top_theme_dir;
   gchar *top_theme_dir_string;
   static gboolean initted = FALSE;
@@ -1783,13 +1784,16 @@ mate_theme_init ()
   theme_hash_by_uri = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   theme_hash_by_name = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
-  /* Add all the toplevel theme dirs. */
-  /* $datadir/themes */
-  top_theme_dir_string = gtk_rc_get_theme_dir ();
-  top_theme_dir = g_file_new_for_path (top_theme_dir_string);
-  g_free (top_theme_dir_string);
-  add_top_theme_dir_monitor (top_theme_dir, 1, NULL);
-  g_object_unref (top_theme_dir);
+  /* Add all the toplevel theme dirs following the XDG Base Directory Specification */
+  dirs = g_get_system_data_dirs ();
+  if (dirs != NULL)
+    for (; *dirs != NULL; ++dirs) {
+      top_theme_dir_string = g_build_filename (*dirs, "themes", NULL);
+      top_theme_dir = g_file_new_for_path (top_theme_dir_string);
+      g_free (top_theme_dir_string);
+      add_top_theme_dir_monitor (top_theme_dir, 1, NULL);
+      g_object_unref (top_theme_dir);
+    }
 
   /* ~/.themes */
   top_theme_dir_string  = g_build_filename (g_get_home_dir (), ".themes", NULL);


### PR DESCRIPTION
Currently `mate-control-center` does not use the mechanisms described in the [XDG Base Directory Specification](http://www.freedesktop.org/Standards/basedir-spec) to locate available themes. In this case the list of directories to look for system themes should be retrieved from the `XDG_DATA_DIRS` environment variable. But it is still using the deprecated function [`gtk_rc_get_theme_dir`](https://gitlab.gnome.org/GNOME/gtk/blob/gtk-3-24/gtk/deprecated/gtkrc.c#L805) (which uses the environment variable `GTK_DATA_PREFIX`).

This affects particularly the [NixOS](https://nixos.org/) package. See https://github.com/NixOS/nixpkgs/issues/75445.

This PR changes mate control center to look for system themes in the system data dirs (defined by the `XDG_DATA_DIRS` environment variable) and is inspired in gnome-control-center.