### PR TITLE
Fix build using gcc 10 -fno-common flag

### DIFF
--- a/capplets/time-admin/src/time-share.c
+++ b/capplets/time-admin/src/time-share.c
@@ -21,6 +21,8 @@
 #include "time-share.h"
 #include <glib/gi18n.h>
 
+int TimeoutFlag;
+
 int ErrorMessage (const char *Title,
                   const char *Msg)
 {

--- a/capplets/time-admin/src/time-share.h
+++ b/capplets/time-admin/src/time-share.h
@@ -33,7 +33,7 @@
 #include <libintl.h>
 #include <gio/gio.h>
 
-int TimeoutFlag;
+extern int TimeoutFlag;
 typedef struct
 {
     GtkWidget        *MainWindow;


### PR DESCRIPTION
```
/usr/bin/ld: time-map.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: multiple definition of `TimeoutFlag'; main.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: first defined here
/usr/bin/ld: time-share.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: multiple definition of `TimeoutFlag'; main.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: first defined here
/usr/bin/ld: time-tool.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: multiple definition of `TimeoutFlag'; main.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: first defined here
/usr/bin/ld: time-zone.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: multiple definition of `TimeoutFlag'; main.o:/home/robert/mate-control-center/capplets/time-admin/src/time-share.h:36: first defined here
```