### PR TITLE
time-admin: dereference of NULL ‘db’ in function ‘CreateCityList’

### DIFF
--- a/capplets/time-admin/src/time-zone.c
+++ b/capplets/time-admin/src/time-zone.c
@@ -363,11 +363,12 @@ static void
 CreateCityList(TimeAdmin *ta)
 {
     TzDB *db;
-    ta->CityListStore = gtk_list_store_new (CITY_NUM_COLS,G_TYPE_STRING,G_TYPE_STRING);
-    db = tz_load_db ();
-    g_ptr_array_foreach (db->locations, (GFunc) LoadCities, ta->CityListStore);
 
-    TimeZoneDateBaseFree(db);
+    ta->CityListStore = gtk_list_store_new (CITY_NUM_COLS, G_TYPE_STRING, G_TYPE_STRING);
+    if ((db = tz_load_db ()) != NULL) {
+        g_ptr_array_foreach (db->locations, (GFunc) LoadCities, ta->CityListStore);
+        TimeZoneDateBaseFree (db);
+    }
 }
 
 static GtkWidget*


### PR DESCRIPTION
GCC 10 analyzer:
```
$ CFLAGS="-fanalyzer" ./autogen.sh --prefix=/usr && make
```
Warning:
```
In function ‘CreateCityList’:
time-zone.c:368:5: warning: dereference of NULL ‘db’ [CWE-690] [-Wanalyzer-null-dereference]
  368 |     g_ptr_array_foreach (db->locations, (GFunc) LoadCities, ta->CityListStore);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ‘SetupTimezoneDialog’: events 1-2
    |
    |  461 | void SetupTimezoneDialog(TimeAdmin *ta)
    |      |      ^~~~~~~~~~~~~~~~~~~
    |      |      |
    |      |      (1) entry to ‘SetupTimezoneDialog’
    |......
    |  505 |     CreateCityList(ta);
    |      |     ~~~~~~~~~~~~~~~~~~
    |      |     |
    |      |     (2) calling ‘CreateCityList’ from ‘SetupTimezoneDialog’
    |
    +--> ‘CreateCityList’: events 3-4
           |
           |  363 | CreateCityList(TimeAdmin *ta)
           |      | ^~~~~~~~~~~~~~
           |      | |
           |      | (3) entry to ‘CreateCityList’
           |......
           |  367 |     db = tz_load_db ();
           |      |          ~~~~~~~~~~~~~
           |      |          |
           |      |          (4) calling ‘tz_load_db’ from ‘CreateCityList’
           |
           +--> ‘tz_load_db’: events 5-6
                  |
                  |  156 | TzDB *tz_load_db (void)
                  |      |       ^~~~~~~~~~
                  |      |       |
                  |      |       (5) entry to ‘tz_load_db’
                  |......
                  |  164 |     if (!tz_data_file)
                  |      |        ~
                  |      |        |
                  |      |        (6) following ‘true’ branch...
                  |
                ‘tz_load_db’: event 7
                  |
                  |/usr/include/glib-2.0/glib/gmessages.h:338:25:
                  |  338 | #define g_warning(...)  g_log (G_LOG_DOMAIN,         \
                  |      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                  |      |                         |
                  |      |                         (7) ...to here
                  |  339 |                                G_LOG_LEVEL_WARNING,  \
                  |      |                                ~~~~~~~~~~~~~~~~~~~~~~~
                  |  340 |                                __VA_ARGS__)
                  |      |                                ~~~~~~~~~~~~
time-zone.c:166:9: note: in expansion of macro ‘g_warning’
                  |  166 |         g_warning ("Could not get the TimeZone data file name");
                  |      |         ^~~~~~~~~
                  |
                ‘tz_load_db’: event 8
                  |
                  |cc1:
                  | (8): assuming ‘<return-value>’ is NULL
                  |
           <------+
           |
         ‘CreateCityList’: events 9-10
           |
           |  367 |     db = tz_load_db ();
           |      |          ^~~~~~~~~~~~~
           |      |          |
           |      |          (9) return of NULL to ‘CreateCityList’ from ‘tz_load_db’
           |  368 |     g_ptr_array_foreach (db->locations, (GFunc) LoadCities, ta->CityListStore);
           |      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           |      |     |
           |      |     (10) dereference of NULL ‘db’
           |
time-zone.c:368:5: note: 1 duplicate
  368 |     g_ptr_array_foreach (db->locations, (GFunc) LoadCities, ta->CityListStore);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```