### PR TITLE
time-admin: dereference of NULL ‘tz_info’ in tz_location_get_utc_offset

### DIFF
--- a/capplets/time-admin/src/time-zone.c
+++ b/capplets/time-admin/src/time-zone.c
@@ -669,11 +669,12 @@ TzInfo *tz_info_from_location (TzLocation *loc)
 glong tz_location_get_utc_offset (TzLocation *loc)
 {
     TzInfo *tz_info;
-    glong offset;
+    glong offset = 0;
 
-    tz_info = tz_info_from_location (loc);
-    offset = tz_info->utc_offset;
-    tz_info_free (tz_info);
+    if ((tz_info = tz_info_from_location (loc)) != NULL) {
+        offset = tz_info->utc_offset;
+        tz_info_free (tz_info);
+    }
 
     return offset;
 }


### PR DESCRIPTION
GCC 10 analyzer:
```
$ CFLAGS="-fanalyzer" ./autogen.sh --prefix=/usr && make
```
Warning:
```
In function ‘tz_location_get_utc_offset’:
time-zone.c:675:12: warning: dereference of NULL ‘tz_info’ [CWE-690] [-Wanalyzer-null-dereference]
  675 |     offset = tz_info->utc_offset;
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~
  ‘tz_location_get_utc_offset’: events 1-2
    |
    |  669 | glong tz_location_get_utc_offset (TzLocation *loc)
    |      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |       |
    |      |       (1) entry to ‘tz_location_get_utc_offset’
    |......
    |  674 |     tz_info = tz_info_from_location (loc);
    |      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |               |
    |      |               (2) calling ‘tz_info_from_location’ from ‘tz_location_get_utc_offset’
    |
    +--> ‘tz_info_from_location’: event 3
           |
           |  623 | TzInfo *tz_info_from_location (TzLocation *loc)
           |      |         ^~~~~~~~~~~~~~~~~~~~~
           |      |         |
           |      |         (3) entry to ‘tz_info_from_location’
           |
         ‘tz_info_from_location’: event 4
           |
           |/usr/include/glib-2.0/glib/gmessages.h:637:8:
           |  637 |     if (G_LIKELY (expr)) \
           |      |        ^
           |      |        |
           |      |        (4) following ‘false’ branch (when ‘loc’ is NULL)...
time-zone.c:630:5: note: in expansion of macro ‘g_return_val_if_fail’
           |  630 |     g_return_val_if_fail (loc != NULL, NULL);
           |      |     ^~~~~~~~~~~~~~~~~~~~
           |
         ‘tz_info_from_location’: event 5
           |
           |/usr/include/glib-2.0/glib/gmessages.h:641:9:
           |  641 |         g_return_if_fail_warning (G_LOG_DOMAIN, \
           |      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           |      |         |
           |      |         (5) ...to here
           |  642 |                                   G_STRFUNC, \
           |      |                                   ~~~~~~~~~~~~
           |  643 |                                   #expr); \
           |      |                                   ~~~~~~
time-zone.c:630:5: note: in expansion of macro ‘g_return_val_if_fail’
           |  630 |     g_return_val_if_fail (loc != NULL, NULL);
           |      |     ^~~~~~~~~~~~~~~~~~~~
           |
         ‘tz_info_from_location’: event 6
           |
           |cc1:
           | (6): assuming ‘<return-value>’ is NULL
           |
    <------+
    |
  ‘tz_location_get_utc_offset’: events 7-8
    |
    |  674 |     tz_info = tz_info_from_location (loc);
    |      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |               |
    |      |               (7) return of NULL to ‘tz_location_get_utc_offset’ from ‘tz_info_from_location’
    |  675 |     offset = tz_info->utc_offset;
    |      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |            |
    |      |            (8) dereference of NULL ‘tz_info’
    |
time-zone.c:675:12: note: 1 duplicate
  675 |     offset = tz_info->utc_offset;
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```