### PR TITLE
glib-genmarshal: Using --header and --body at the same time is deprecated

### DIFF
--- a/capplets/about-me/Makefile.am
+++ b/capplets/about-me/Makefile.am
@@ -20,7 +20,7 @@ mate_about_me_SOURCES =	 	\
 marshal.h: fprintd-marshal.list
 	@GLIB_GENMARSHAL@ --prefix=fprintd_marshal $< --header > $@
 marshal.c: fprintd-marshal.list
-	@GLIB_GENMARSHAL@ --prefix=fprintd_marshal $< --body --header > $@
+	@GLIB_GENMARSHAL@ --prefix=fprintd_marshal $< --body --prototypes > $@
 mate-about-me-resources.h mate-about-me-resources.c: org.mate.mcc.am.gresource.xml Makefile $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies --sourcedir $(srcdir) $(srcdir)/org.mate.mcc.am.gresource.xml)
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate --c-name about_me $<
 

--- a/capplets/display/Makefile.am
+++ b/capplets/display/Makefile.am
@@ -56,7 +56,7 @@ AM_CPPFLAGS   = $(DISPLAY_CAPPLET_CFLAGS) \
 foo-marshal.c: foo-marshal.list
 	@GLIB_GENMARSHAL@ --prefix=foo_marshal $< --header > $@
 foo-marshal.h: foo-marshal.list
-	@GLIB_GENMARSHAL@ --prefix=foo_marshal $< --body --header > $@
+	@GLIB_GENMARSHAL@ --prefix=foo_marshal $< --body --prototypes > $@
 mate-display-properties-resources.h mate-display-properties-resources.c: org.mate.mcc.display.gresource.xml Makefile $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies --sourcedir $(srcdir) $(srcdir)/org.mate.mcc.display.gresource.xml)
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate --c-name display $<
 


### PR DESCRIPTION
`WARNING: Using --header and --body at the same time is deprecated; use --body --prototypes instead`