### PR TITLE
Compiler flags

### DIFF
--- a/capplets/about-me/Makefile.am
+++ b/capplets/about-me/Makefile.am
@@ -40,6 +40,7 @@ $(desktop_DATA): $(Desktop_in_files)
 include $(top_srcdir)/gla11y.mk
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(LIBEBOOK_CFLAGS) \
 	-DDATADIR="\"$(datadir)\"" \

--- a/capplets/accessibility/at-properties/Makefile.am
+++ b/capplets/accessibility/at-properties/Makefile.am
@@ -27,10 +27,12 @@ pixmap_DATA =					\
 
 include $(top_srcdir)/gla11y.mk
 
-AM_CPPFLAGS   = $(AT_CAPPLET_CFLAGS)     \
-             $(MATECC_CAPPLETS_CFLAGS) \
-	     -DPIXMAPDIR=\""$(pixmapdir)"\" \
-	     -DMATECC_DATA_DIR="\"$(pkgdatadir)\""
+AM_CPPFLAGS =					\
+	$(WARN_CFLAGS)				\
+	$(AT_CAPPLET_CFLAGS)			\
+	$(MATECC_CAPPLETS_CFLAGS)		\
+	-DPIXMAPDIR=\""$(pixmapdir)"\"		\
+	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""
 CLEANFILES = $(MATECC_CAPPLETS_CLEANFILES) $(desktop_DATA) $(BUILT_SOURCES)
 EXTRA_DIST = \
 	$(ui_files) \

--- a/capplets/appearance/Makefile.am
+++ b/capplets/appearance/Makefile.am
@@ -52,6 +52,7 @@ wallpaperdir = $(datadir)/mate-background-properties
 backgrounddir = $(datadir)/backgrounds
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MARCO_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(FONT_CAPPLET_CFLAGS) \

--- a/capplets/common/Makefile.am
+++ b/capplets/common/Makefile.am
@@ -2,19 +2,20 @@ EXTRA_DIST =
 
 AM_CPPFLAGS = \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""				\
-	-DMATELOCALEDIR="\"$(datadir)/locale\""			\
+	-DMATELOCALEDIR="\"$(datadir)/locale\""				\
 	-DGTK_ENGINE_DIR="\"$(GTK_ENGINE_DIR)\"" 			\
 	-DG_LOG_DOMAIN=\"capplet-common\"				\
 	-DINSTALL_PREFIX=\"$(prefix)\"					\
 	-I$(top_srcdir)							\
 	-I$(top_srcdir)/libwindow-settings				\
 	-DPIXMAP_DIR=\""$(datadir)/mate-control-center/pixmaps"\"	\
+	$(WARN_CFLAGS)							\
 	$(CAPPLET_CFLAGS)						\
 	$(DBUS_CFLAGS)							\
 	$(MATE_DESKTOP_CFLAGS)						\
-	$(MARCO_CFLAGS)						\
+	$(MARCO_CFLAGS)							\
 	$(GSD_DBUS_CFLAGS)						\
-	$(GIO_CFLAGS)						\
+	$(GIO_CFLAGS)							\
 	$(DCONF_CFLAGS)
 
 
@@ -25,8 +26,8 @@ libcommon_la_SOURCES = \
 	activate-settings-daemon.h	\
 	capplet-util.c			\
 	capplet-util.h			\
-	dconf-util.c				\
-	dconf-util.h				\
+	dconf-util.c			\
+	dconf-util.h			\
 	file-transfer-dialog.c		\
 	file-transfer-dialog.h		\
 	mate-theme-apply.c		\

--- a/capplets/default-applications/Makefile.am
+++ b/capplets/default-applications/Makefile.am
@@ -29,6 +29,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = mate-default-applications.pc
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(DEFAULT_APPLICATIONS_CAPPLET_CFLAGS) \
 	-DAPPLICATIONSDIR=\""$(datadir)/applications"\"

--- a/capplets/display/Makefile.am
+++ b/capplets/display/Makefile.am
@@ -47,11 +47,13 @@ desktop_DATA = $(Desktop_in_files:.desktop.in=.desktop)
 $(desktop_DATA): $(Desktop_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
-AM_CPPFLAGS   = $(DISPLAY_CAPPLET_CFLAGS) \
-             $(MATECC_CAPPLETS_CFLAGS) \
-	     -DSBINDIR="\"$(sbindir)\"" \
-	     -DMATELOCALEDIR="\"$(datadir)/locale\"" \
-	     -DMATECC_DATA_DIR="\"$(pkgdatadir)\""
+AM_CPPFLAGS =					\
+	$(WARN_CFLAGS)				\
+	$(DISPLAY_CAPPLET_CFLAGS)		\
+	$(MATECC_CAPPLETS_CFLAGS)		\
+	-DSBINDIR="\"$(sbindir)\""		\
+	-DMATELOCALEDIR="\"$(datadir)/locale\""	\
+	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""
 
 foo-marshal.c: foo-marshal.list
 	@GLIB_GENMARSHAL@ --prefix=foo_marshal $< --header > $@

--- a/capplets/keybindings/Makefile.am
+++ b/capplets/keybindings/Makefile.am
@@ -38,6 +38,7 @@ mate-keybinding-properties-resources.h mate-keybinding-properties-resources.c: o
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate --c-name keybindings $<
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""
 CLEANFILES = \

--- a/capplets/keyboard/Makefile.am
+++ b/capplets/keyboard/Makefile.am
@@ -40,6 +40,7 @@ mate-keyboard-properties-resources.h mate-keyboard-properties-resources.c: org.m
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate --c-name keyboard $<
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(LIBMATEKBDUI_CFLAGS) \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""

--- a/capplets/mouse/Makefile.am
+++ b/capplets/mouse/Makefile.am
@@ -27,6 +27,7 @@ mate-mouse-properties-resources.h mate-mouse-properties-resources.c: org.mate.mc
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate --c-name mouse $<
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\""
 CLEANFILES = $(MATECC_CAPPLETS_CLEANFILES) $(desktop_DATA) $(BUILT_SOURCES)

--- a/capplets/network/Makefile.am
+++ b/capplets/network/Makefile.am
@@ -24,6 +24,7 @@ mate-network-properties-resources.h mate-network-properties-resources.c: org.mat
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate --c-name network $<
 
 AM_CPPFLAGS = \
+	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS)
 
 CLEANFILES = $(MATECC_CAPPLETS_CLEANFILES) $(desktop_DATA) $(BUILT_SOURCES)

--- a/capplets/time-admin/src/Makefile.am
+++ b/capplets/time-admin/src/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = mate-time-admin
 
 BUILT_SOURCES = mate-time-admin-resources.h mate-time-admin-resources.c
 nodist_mate_time_admin_SOURCES = $(BUILT_SOURCES)
-mate_time_admin_SOURCES =	 	\
+mate_time_admin_SOURCES =		\
 	main.c       time-map.c  time-share.c  time-tool.c  time-zone.c \
 	time-map.h  time-share.h  time-tool.h  time-zone.h
 
@@ -14,8 +14,9 @@ mate-time-admin-resources.h mate-time-admin-resources.c: org.mate.mcc.ta.gresour
 mate_time_admin_LDADD = $(MATECC_CAPPLETS_LIBS)
 mate_time_admin_LDFLAGS = -export-dynamic
 
-AM_CPPFLAGS = \
-	$(MATECC_CAPPLETS_CFLAGS) \
+AM_CPPFLAGS =				\
+	$(WARN_CFLAGS)			\
+	$(MATECC_CAPPLETS_CFLAGS)	\
 	-DTIMPZONEDIR="\"$(datadir)/mate-time-admin/map/\""
 
 

--- a/capplets/windows/Makefile.am
+++ b/capplets/windows/Makefile.am
@@ -22,9 +22,11 @@ mate-window-properties-resources.h mate-window-properties-resources.c: org.mate.
 $(desktop_DATA): $(Desktop_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
-AM_CPPFLAGS   = $(MATECC_CAPPLETS_CFLAGS)					\
-	     -DUIDIR=\""$(uidir)"\"  	\
-	     -DPIXMAPDIR=\""$(pixmapdir)"\"
+AM_CPPFLAGS =				\
+	$(WARN_CFLAGS)			\
+	$(MATECC_CAPPLETS_CFLAGS)	\
+	-DUIDIR=\""$(uidir)"\"		\
+	-DPIXMAPDIR=\""$(pixmapdir)"\"
 
 CLEANFILES = $(BUILT_SOURCES) $(MATECC_CAPPLETS_CLEANFILES) $(desktop_DATA)
 EXTRA_DIST = $(Desktop_in_files) org.mate.mcc.windows.gresource.xml window-properties.ui

--- a/configure.ac
+++ b/configure.ac
@@ -316,6 +316,11 @@ dnl ---------------------------------------------------------------------------
 echo "
               mate-control-center
 
+        Compiler:              ${CC}
+        Compiler flags:        ${CFLAGS}
+        Warning flags:         ${WARN_CFLAGS}
+        Linker flags:          ${LDFLAGS}
+
         Appindicator:          ${enable_appindicator}
         Libmate-slab:          ${have_libmateslab}
         Accountsservice:       ${have_accountsservice}

--- a/configure.ac
+++ b/configure.ac
@@ -22,15 +22,6 @@ AC_PATH_PROG([GLA11Y], [gla11y], [true])
 # Use the Yelp documentation framework
 YELP_HELP_INIT
 
-changequote(,)dnl
-if test "x$GCC" = "xyes"; then
-  case " $CFLAGS " in
-  *[\ \	]-Wall[\ \	]*) ;;
-  *) CFLAGS="$CFLAGS -Wall" ;;
-  esac
-fi
-changequote([,])dnl
-
 # Internationalization support
 AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
@@ -172,7 +163,6 @@ PKG_CHECK_MODULES(LIBSLAB, [
 			   ],
 			   have_libmateslab=yes,
 			   have_libmateslab=no)
-WARN_CFLAGS="-Wall"
 
 AC_SUBST(LIBMATESLAB_CFLAGS)
 AC_SUBST(LIBMATESLAB_LIBS)

--- a/font-viewer/Makefile.am
+++ b/font-viewer/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = $(FONT_VIEWER_CFLAGS) $(MATECC_CAPPLETS_CFLAGS) -DDIRECTORY_DIR=\"$(directorydir)\" \
+AM_CPPFLAGS = $(WARN_CFLAGS) $(FONT_VIEWER_CFLAGS) $(MATECC_CAPPLETS_CFLAGS) -DDIRECTORY_DIR=\"$(directorydir)\" \
   -DMATELOCALEDIR=\"$(datadir)/locale\"
 
 bin_PROGRAMS = mate-thumbnail-font mate-font-viewer

--- a/libwindow-settings/Makefile.am
+++ b/libwindow-settings/Makefile.am
@@ -1,12 +1,13 @@
 WM_MODULE_DIR=$(libdir)/window-manager-settings
 
 AM_CPPFLAGS = 								\
-	-DMATELOCALEDIR="\"$(datadir)/locale\""			\
-	-DMATE_ICONDIR=\""$(datadir)/pixmaps"\"			\
+	-DMATELOCALEDIR="\"$(datadir)/locale\""				\
+	-DMATE_ICONDIR=\""$(datadir)/pixmaps"\"				\
 	-DG_LOG_DOMAIN=\"capplet-common\"				\
 	-DMATE_WM_PROPERTY_PATH=\"$(datadir)/mate/wm-properties\"	\
 	-DMATE_WINDOW_MANAGER_MODULE_PATH=\""$(WM_MODULE_DIR)"\"	\
 	-I$(top_srcdir)/						\
+	$(WARN_CFLAGS)							\
 	@CAPPLET_CFLAGS@						\
 	-DMARCO_THEME_DIR=\""$(datadir)/themes"\"
 

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -3,11 +3,12 @@ REAL_LIBSLAB_LIBS = $(top_builddir)/libslab/libmate-slab.la
 
 AM_CPPFLAGS =					\
 	-I$(top_srcdir)				\
-	$(REAL_LIBSLAB_CFLAGS)		\
-	$(MATECC_SHELL_CFLAGS)  	\
+	$(WARN_CFLAGS)				\
+	$(REAL_LIBSLAB_CFLAGS)			\
+	$(MATECC_SHELL_CFLAGS)			\
 	-DMATELOCALEDIR="\"$(datadir)/locale\""
 
-bin_PROGRAMS = mate-control-center 
+bin_PROGRAMS = mate-control-center
 
 mate_control_center_SOURCES =		\
 	control-center.c

--- a/typing-break/Makefile.am
+++ b/typing-break/Makefile.am
@@ -22,6 +22,7 @@ mate_typing_monitor_CPPFLAGS = \
 mate_typing_monitor_CFLAGS = \
 	@TYPING_CFLAGS@	\
 	@MATE_DESKTOP_CFLAGS@ \
+	$(WARN_CFLAGS) \
 	$(AM_CFLAGS)
 
 mate_typing_monitor_LDADD = @TYPING_LIBS@ @MATE_DESKTOP_LIBS@ @SCREENSAVER_LIBS@


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum --enable-debug
<cut>

              mate-control-center

        Compiler:              gcc
        Compiler flags:         -g -O0
        Warning flags:         -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare
        Linker flags:          

        Appindicator:          yes
        Libmate-slab:          yes
        Accountsservice:       yes

Now type `make' to compile mate-control-center
<cut>
```