### PR TITLE
mate-about-me: Fix memory leak

### DIFF
--- a/capplets/about-me/mate-about-me.c
+++ b/capplets/about-me/mate-about-me.c
@@ -201,6 +201,7 @@ about_me_update_photo (MateAboutMe *me)
 
 		g_free (file);
 		g_object_unref (pixbuf);
+		g_free (data);
 	} else if (me->image_changed && !me->have_image) {
 		/* Update the image in the card */
 		file = g_build_filename (g_get_home_dir (), ".face", NULL);


### PR DESCRIPTION
Build & install:
```
$  CFLAGS="-g -O0 -fsanitize=address" ./autogen.sh --prefix=/usr && make V=1 && sudo make install
```
Run:
```
$ mate-about-me
```
Detected memory leak:
```
Direct leak of 7040 byte(s) in 1 object(s) allocated from:
    #0 0x7f4566e66c58 in __interceptor_malloc (/lib64/libasan.so.5+0x10dc58)
    #1 0x7f45657b0358 in g_malloc (/lib64/libglib-2.0.so.0+0x57358)
    #2 0x414b8d in about_me_update_photo /home/robert/sanitizer/mate-control-center/capplets/about-me/mate-about-me.c:141
    #3 0x415a37 in about_me_image_changed_cb /home/robert/sanitizer/mate-control-center/capplets/about-me/mate-about-me.c:358
    #4 0x7f4565894741 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x13741)
```
Edit: Install the required libraries before Build & install:
```
# dnf install libasan libasan-static
```