### PR TITLE
appearance: Fix memory leak

### DIFF
--- a/capplets/appearance/appearance-themes.c
+++ b/capplets/appearance/appearance-themes.c
@@ -1001,7 +1001,6 @@ void themes_init(AppearanceData* data)
   data->theme_message_area = NULL;
   data->theme_info_icon = NULL;
   data->theme_error_icon = NULL;
-  data->theme_custom = mate_theme_meta_info_new ();
   data->theme_icon = gdk_pixbuf_new_from_file (MATECC_PIXMAP_DIR "/theme-thumbnailing.png", NULL);
   data->theme_store = theme_store =
       gtk_list_store_new (NUM_COLS, GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_STRING);


### PR DESCRIPTION
`mate_theme_meta_info_new ()` was called two times.
- `data->theme_custom = mate_theme_meta_info_new ();`
- `data->theme_custom = theme_load_from_gsettings (data);`

```shell
$ CFLAGS="-g -O0 -fsanitize=address" ./autogen.sh --prefix=/usr && make && sudo make install
$ mate-appearance-properties
```
```
Direct leak of 168 byte(s) in 1 object(s) allocated from:
    #0 0x7f4e87b40e56 in __interceptor_calloc (/lib64/libasan.so.5+0x10de56)
    #1 0x7f4e8648a3b0 in g_malloc0 (/lib64/libglib-2.0.so.0+0x573b0)
    #2 0x42252f in themes_init /home/robert/sanitizer/mate-control-center/capplets/appearance/appearance-themes.c:1004
    #3 0x41bf62 in main /home/robert/sanitizer/mate-control-center/capplets/appearance/appearance-main.c:182
    #4 0x7f4e861271a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)
```