### PR TITLE
windows: Remove unused function

### DIFF
--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -292,23 +292,6 @@ response_cb (GtkWidget *dialog_win,
     }
 }
 
-GtkWidget*
-title_label_new (const char* title)
-{
-    GtkWidget *widget;
-    gchar *str;
-
-    str = g_strdup_printf ("<b>%s</b>", _(title));
-    widget = gtk_label_new (str);
-    g_free (str);
-
-    gtk_label_set_use_markup (GTK_LABEL (widget), TRUE);
-    gtk_label_set_xalign (GTK_LABEL (widget), 0.0);
-    gtk_label_set_yalign (GTK_LABEL (widget), 0.0);
-
-    return widget;
-}
-
 int
 main (int argc, char **argv)
 {


### PR DESCRIPTION
Test: `title_label_new` appears in the list of unused functions
```shell
$ CFLAGS="-pg" LDFLAGS="-pg" ./autogen.sh --prefix=/usr && make && sudo make install
$ cd capplets/windows/.libs
$ ./mate-window-properties
$ gprof -z ./mate-window-properties
```
Before:
```
Index by function name

  [34] __do_global_dtors_aux  [14] capplet_help           [25] mouse_focus_toggled_callback
  [35] __gmon_start__          [2] capplet_init           [26] register_tm_clones
  [36] __libc_csu_fini        [15] capplet_set_icon        [4] reload_mouse_modifiers
  [37] __libc_csu_init        [16] data_start              [5] resource_constructor
  [38] _dl_relocate_static_pie [17] deregister_tm_clones  [27] resource_destructor
  [39] _fini                  [18] directory_delete_recursive [28] response_cb
  [40] _init                  [19] double_click_titlebar_changed_callback [6] set_alt_click_value
  [41] _start                 [20] etext                  [29] title_label_new
   [8] alt_click_radio_toggled_callback [1] fill_radio    [30] titlebar_layout_changed_callback
   [9] atexit                 [21] frame_dummy             [7] update_sensitivity
  [10] autoraise_delay_value_changed_callback [22] main   [31] window_properties_get_resource
  [11] capplet_dialog_page_scroll_event_cb [23] marco_settings_changed_callback [32] wm_changed_callback
  [12] capplet_error_dialog   [24] mate_metacity_config_tool [33] wm_unsupported
  [13] capplet_file_delete_recursive [3] mouse_focus_changed_callback
```
After:
```
Index by function name

  [33] __do_global_dtors_aux  [14] capplet_help           [25] mouse_focus_toggled_callback
  [34] __gmon_start__          [2] capplet_init           [26] register_tm_clones
  [35] __libc_csu_fini        [15] capplet_set_icon        [4] reload_mouse_modifiers
  [36] __libc_csu_init        [16] data_start              [5] resource_constructor
  [37] _dl_relocate_static_pie [17] deregister_tm_clones  [27] resource_destructor
  [38] _fini                  [18] directory_delete_recursive [28] response_cb
  [39] _init                  [19] double_click_titlebar_changed_callback [6] set_alt_click_value
  [40] _start                 [20] etext                  [29] titlebar_layout_changed_callback
   [8] alt_click_radio_toggled_callback [1] fill_radio     [7] update_sensitivity
   [9] atexit                 [21] frame_dummy            [30] window_properties_get_resource
  [10] autoraise_delay_value_changed_callback [22] main   [31] wm_changed_callback
  [11] capplet_dialog_page_scroll_event_cb [23] marco_settings_changed_callback [32] wm_unsupported
  [12] capplet_error_dialog   [24] mate_metacity_config_tool
  [13] capplet_file_delete_recursive [3] mouse_focus_changed_callback
```
`title_label_new` can be safely removed after #520