### PR TITLE
libslab: Remove libslab_get_current_time_millis

### DIFF
--- a/libslab/double-click-detector.c
+++ b/libslab/double-click-detector.c
@@ -26,6 +26,8 @@
 
 G_DEFINE_TYPE (DoubleClickDetector, double_click_detector, G_TYPE_OBJECT);
 
+void double_click_detector_update_click_time (DoubleClickDetector * detector, guint32 event_time);
+
 static void
 double_click_detector_class_init (DoubleClickDetectorClass * detector_class)
 {
@@ -41,7 +43,7 @@ double_click_detector_init (DoubleClickDetector * detector)
 
 	g_object_get (G_OBJECT (settings), "gtk-double-click-time", &click_interval, NULL);
 
-	detector->double_click_time = (guint32) click_interval;
+	detector->double_click_time = (gint32) click_interval;
 	detector->last_click_time = 0;
 }
 
@@ -57,17 +59,17 @@ double_click_detector_is_double_click (DoubleClickDetector *this, guint32 event_
 {
 	gint32 delta;
 
-	if (event_time <= 0)
-		event_time = libslab_get_current_time_millis ();
+	if (event_time == 0)
+		event_time = (guint32) (g_get_monotonic_time () / 1000); /* milliseconds */
 
-	if (this->last_click_time <= 0) {
+	if (this->last_click_time == 0) {
 		if (auto_update)
 			double_click_detector_update_click_time (this, event_time);
 
 		return FALSE;
 	}
 
-	delta = event_time - this->last_click_time;
+	delta = (gint32) event_time - (gint32) this->last_click_time;
 
 	if (auto_update)
 		double_click_detector_update_click_time (this, event_time);
@@ -78,8 +80,8 @@ double_click_detector_is_double_click (DoubleClickDetector *this, guint32 event_
 void
 double_click_detector_update_click_time (DoubleClickDetector *this, guint32 event_time)
 {
-	if (event_time <= 0)
-		event_time = libslab_get_current_time_millis ();
+	if (event_time == 0)
+		event_time = (guint32) (g_get_monotonic_time () / 1000); /* milliseconds */
 
 	this->last_click_time = event_time;
 }

--- a/libslab/double-click-detector.h
+++ b/libslab/double-click-detector.h
@@ -38,7 +38,7 @@ typedef struct
 {
 	GObject parent_placeholder;
 
-	guint32 double_click_time;
+	gint32 double_click_time;
 	guint32 last_click_time;
 } DoubleClickDetector;
 
@@ -53,8 +53,6 @@ DoubleClickDetector *double_click_detector_new (void);
 
 gboolean double_click_detector_is_double_click (DoubleClickDetector * detector, guint32 event_time,
 	gboolean auto_update);
-
-void double_click_detector_update_click_time (DoubleClickDetector * detector, guint32 event_time);
 
 #ifdef __cplusplus
 }

--- a/libslab/libslab-utils.c
+++ b/libslab/libslab-utils.c
@@ -93,16 +93,6 @@ libslab_get_current_screen (void)
 	return screen;
 }
 
-guint32
-libslab_get_current_time_millis ()
-{
-	GTimeVal t_curr;
-
-	g_get_current_time (& t_curr);
-
-	return 1000L * t_curr.tv_sec + t_curr.tv_usec / 1000L;
-}
-
 gint
 libslab_strcmp (const gchar *a, const gchar *b)
 {

--- a/libslab/libslab-utils.h
+++ b/libslab/libslab-utils.h
@@ -10,7 +10,6 @@ extern "C" {
 #endif
 
 MateDesktopItem *libslab_mate_desktop_item_new_from_unknown_id (const gchar *id);
-guint32           libslab_get_current_time_millis (void);
 gint              libslab_strcmp (const gchar *a, const gchar *b);
 void              libslab_handle_g_error (GError **error, const gchar *msg_format, ...);
 


### PR DESCRIPTION
Removed warnings:
```
libslab-utils.c:99:2: warning: ‘GTimeVal’ is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   99 |  GTimeVal t_curr;
      |  ^~~~~~~~
libslab-utils.c:101:2: warning: ‘g_get_current_time’ is deprecated: Use 'g_get_real_time' instead [-Wdeprecated-declarations]
  101 |  g_get_current_time (& t_curr);
      |  ^~~~~~~~~~~~~~~~~~
```