### PR TITLE
typing-break: Remove warning ‘GTimeVal’ is deprecated

### DIFF
--- a/typing-break/drw-timer.c
+++ b/typing-break/drw-timer.c
@@ -23,7 +23,7 @@
 
 struct _DrwTimer
 {
-	GTimeVal start_time;
+	gint64 start_time;
 };
 
 DrwTimer * drw_timer_new ()
@@ -35,14 +35,12 @@ DrwTimer * drw_timer_new ()
 
 void drw_timer_start (DrwTimer *timer)
 {
-	g_get_current_time (&timer->start_time);
+	timer->start_time = g_get_real_time ();
 }
 
-double drw_timer_elapsed (DrwTimer *timer)
+gint drw_timer_elapsed (DrwTimer *timer)
 {
-	GTimeVal now;
-	g_get_current_time (&now);
-	return now.tv_sec - timer->start_time.tv_sec;
+	return (g_get_real_time () - timer->start_time) / G_USEC_PER_SEC;
 }
 
 void drw_timer_destroy (DrwTimer *timer)

--- a/typing-break/drw-timer.h
+++ b/typing-break/drw-timer.h
@@ -36,7 +36,7 @@
 typedef struct _DrwTimer DrwTimer;
 DrwTimer * drw_timer_new ();
 void drw_timer_start (DrwTimer *timer);
-double drw_timer_elapsed (DrwTimer *timer);
+gint drw_timer_elapsed (DrwTimer *timer);
 void drw_timer_destroy (DrwTimer *timer);
 
 #endif /* __DRW_TIMER_H__ */


### PR DESCRIPTION
Test: Enable typing break on mate-keyboard-properties

![Screenshot at 2020-03-03 13-33-16](https://user-images.githubusercontent.com/10171411/75776293-02924d80-5d54-11ea-8987-f51af085a58d.png)

![VirtualBox_11 Fedora Rawhide_03_03_2020_13_34_38](https://user-images.githubusercontent.com/10171411/75776355-23f33980-5d54-11ea-8d27-124f00522c5c.png)


Removed warnings:
```
drw-timer.c:26:2: warning: ‘GTimeVal’ is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   26 |  GTimeVal start_time;
      |  ^~~~~~~~
drw-timer.c:38:2: warning: ‘g_get_current_time’ is deprecated: Use 'g_get_real_time' instead [-Wdeprecated-declarations]
   38 |  g_get_current_time (&timer->start_time);
      |  ^~~~~~~~~~~~~~~~~~
drw-timer.c:43:2: warning: ‘GTimeVal’ is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   43 |  GTimeVal now;
      |  ^~~~~~~~
drw-timer.c:44:2: warning: ‘g_get_current_time’ is deprecated: Use 'g_get_real_time' instead [-Wdeprecated-declarations]
   44 |  g_get_current_time (&now);
```