### PR TITLE
Port libslab_handle_g_error to the built-in GLib logging framework

### DIFF
--- a/libslab/Makefile.am
+++ b/libslab/Makefile.am
@@ -2,6 +2,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = mate-slab.pc
 
 AM_CPPFLAGS =					\
+	-DG_LOG_DOMAIN=\"libslab\"		\
 	-I$(top_srcdir)				\
 	$(LIBSLAB_CFLAGS)			\
 	$(WARN_CFLAGS)

--- a/libslab/libslab-utils.c
+++ b/libslab/libslab-utils.c
@@ -107,29 +107,3 @@ libslab_strcmp (const gchar *a, const gchar *b)
 
 	return strcmp (a, b);
 }
-
-void
-libslab_handle_g_error (GError **error, const gchar *msg_format, ...)
-{
-	gchar   *msg;
-	va_list  args;
-
-
-	va_start (args, msg_format);
-	msg = g_strdup_vprintf (msg_format, args);
-	va_end (args);
-
-	if (*error) {
-		g_log (
-			G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
-			"\nGError raised: [%s]\nuser_message: [%s]\n", (*error)->message, msg);
-
-		g_error_free (*error);
-
-		*error = NULL;
-	}
-	else
-		g_log (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "\nerror raised: [%s]\n", msg);
-
-	g_free (msg);
-}

--- a/libslab/libslab-utils.h
+++ b/libslab/libslab-utils.h
@@ -11,7 +11,6 @@ extern "C" {
 
 MateDesktopItem *libslab_mate_desktop_item_new_from_unknown_id (const gchar *id);
 gint              libslab_strcmp (const gchar *a, const gchar *b);
-void              libslab_handle_g_error (GError **error, const gchar *msg_format, ...);
 
 GdkScreen *libslab_get_current_screen (void);
 


### PR DESCRIPTION
Closes #554

test:
```shell
$ G_MESSAGES_DEBUG=libslab mate-control-center
(mate-control-center:98895): libslab-DEBUG: 12:03:52.651: Couldn't load bookmark file [NULL]
```
test 2:
```
$ mate-control-center 
$ cat ~/.xsession-errors
```