### PR TITLE
appearance-ui: Remove unused function button_press_block_cb

### DIFF
--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -68,16 +68,6 @@ menus_have_icons_cb (GSettings *settings,
     set_have_icons (data, g_settings_get_boolean (settings, key));
 }
 
-/** GUI Callbacks **/
-
-static gint
-button_press_block_cb (GtkWidget *toolbar,
-                       GdkEvent  *event,
-                       gpointer   data)
-{
-    return TRUE;
-}
-
 /** Public Functions **/
 
 void


### PR DESCRIPTION
```
appearance-ui.c:74:1: warning: ‘button_press_block_cb’ defined but not used [-Wunused-function]
   74 | button_press_block_cb (GtkWidget *toolbar,
      | ^~~~~~~~~~~~~~~~~~~~~
```