### PR TITLE
[WIP] To fix : More than one of the same preferences window can be opened

### DIFF
--- a/capplets/Makefile.am
+++ b/capplets/Makefile.am
@@ -1,15 +1,5 @@
 SUBDIRS = \
 	common \
-	accessibility \
-	appearance \
-	default-applications \
-	display \
-	keyboard \
-	keybindings \
-	mouse \
-	network \
-	time-admin \
-	windows \
 	about-me
 
 DIST_SUBDIRS = \

--- a/capplets/about-me/Makefile.am
+++ b/capplets/about-me/Makefile.am
@@ -26,7 +26,8 @@ mate-about-me-resources.h mate-about-me-resources.c: org.mate.mcc.am.gresource.x
 
 bin_PROGRAMS = mate-about-me
 
-mate_about_me_LDADD = $(MATECC_CAPPLETS_LIBS)
+mate_about_me_LDADD = $(MATECC_CAPPLETS_LIBS)		\
+	$(LIBWNCK_LIBS)
 if HAVE_ACCOUNTSSERVICE
 mate_about_me_LDADD += $(ACCOUNTSSERVICE_LIBS)
 endif
@@ -43,6 +44,7 @@ AM_CPPFLAGS = \
 	$(WARN_CFLAGS) \
 	$(MATECC_CAPPLETS_CFLAGS) \
 	$(LIBEBOOK_CFLAGS) \
+	$(LIBWNCK_CFLAGS)			\
 	-DDATADIR="\"$(datadir)\"" \
 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\"" \
 	-DMATECC_PIXMAP_DIR="\"$(pkgdatadir)/pixmaps\"" \

--- a/capplets/about-me/mate-about-me.c
+++ b/capplets/about-me/mate-about-me.c
@@ -435,6 +435,15 @@ about_me_setup_dialog (void)
 	ActUserManager* manager;
 #endif
 
+	str = g_strdup_printf (_("About %s"), g_strdup (g_get_real_name ()));
+
+	if (capplet_window_exists (str))
+	{
+		return -1;
+	}
+
+	g_free (str);
+
 	me = g_new0 (MateAboutMe, 1);
 	me->image = NULL;
 

--- a/capplets/appearance/data/appearance.ui
+++ b/capplets/appearance/data/appearance.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 
+<!-- Generated with glade 3.22.2
 
 mate-appearance-properties - appearance properties dialog window
 Copyright (C) MATE Developers
@@ -22,7 +22,7 @@ Author: Wolfgang Ulbrich
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-appearance-properties -->
   <!-- interface-description appearance properties dialog window -->

--- a/capplets/common/Makefile.am
+++ b/capplets/common/Makefile.am
@@ -16,6 +16,7 @@ AM_CPPFLAGS = \
 	$(MARCO_CFLAGS)							\
 	$(GSD_DBUS_CFLAGS)						\
 	$(GIO_CFLAGS)							\
+	$(LIBWNCK_CFLAGS)			\
 	$(DCONF_CFLAGS)
 
 
@@ -47,6 +48,7 @@ libcommon_la_LIBADD =							\
 	$(DBUS_LIBS)							\
 	$(MATE_DESKTOP_LIBS)						\
 	$(GIO_LIBS)									\
+	$(LIBWNCK_LIBS)				\
 	$(DCONF_LIBS)
 
 mate_theme_test_SOURCES = \

--- a/capplets/common/capplet-util.c
+++ b/capplets/common/capplet-util.c
@@ -255,3 +255,33 @@ capplet_init (GOptionContext *context,
 
 	gtk_init (argc, argv);
 }
+
+gboolean
+capplet_window_exists(const char *title)
+{
+	const char *window_title;
+	WnckScreen *screen;
+	GList *window_l;
+	gboolean window_exists;
+
+	screen = wnck_screen_get_default ();
+	wnck_screen_force_update (screen);
+
+	window_exists = FALSE;
+
+	for (window_l = wnck_screen_get_windows (screen); window_l != NULL; window_l = window_l->next)
+	{
+		WnckWindow *window = WNCK_WINDOW (window_l->data);
+		if (wnck_window_has_name (window))
+		{
+			window_title = wnck_window_get_name (window);
+			if (g_strcmp0(window_title, title) == 0)
+			{
+				window_exists = TRUE;
+				break;
+			}
+		}
+	}
+
+	return window_exists;
+}

--- a/capplets/common/capplet-util.h
+++ b/capplets/common/capplet-util.h
@@ -41,5 +41,6 @@ void capplet_set_icon (GtkWidget *window, char const *icon_file_name);
 gboolean capplet_file_delete_recursive (GFile *directory, GError **error);
 gboolean capplet_dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window);
 void capplet_init (GOptionContext *context, int *argc, char ***argv);
+gboolean capplet_window_exists(const char *title);
 
 #endif /* __CAPPLET_UTIL_H */

--- a/capplets/default-applications/mate-default-applications-properties.ui
+++ b/capplets/default-applications/mate-default-applications-properties.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-default-applications-properties -->
   <!-- interface-description mate-default-applications-properties window -->

--- a/capplets/keybindings/mate-keybinding-properties.ui
+++ b/capplets/keybindings/mate-keybinding-properties.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-keybinding-dialog.ui -->
   <!-- interface-description dialo window for changing keybindings -->

--- a/capplets/keyboard/mate-keyboard-properties-a11y-notifications.ui
+++ b/capplets/keyboard/mate-keyboard-properties-a11y-notifications.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-keyboard-properties-a11y-notifications.ui -->
   <!-- interface-description a11y keyboard notifications dialog window -->

--- a/capplets/keyboard/mate-keyboard-properties-dialog.ui
+++ b/capplets/keyboard/mate-keyboard-properties-dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-keyboard-properties-dialog -->
   <!-- interface-description keyboard properties dialog window -->

--- a/capplets/keyboard/mate-keyboard-properties-layout-chooser.ui
+++ b/capplets/keyboard/mate-keyboard-properties-layout-chooser.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-keyboard-properties-layout-chooser -->
   <!-- interface-description keyboard properties layout dialog window -->

--- a/capplets/keyboard/mate-keyboard-properties-model-chooser.ui
+++ b/capplets/keyboard/mate-keyboard-properties-model-chooser.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-keyboard-properties-model-chooser -->
   <!-- interface-description keyboard model chooser dialog window -->

--- a/capplets/keyboard/mate-keyboard-properties-options-dialog.ui
+++ b/capplets/keyboard/mate-keyboard-properties-options-dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-keyboard-properties-options-dialog -->
   <!-- interface-description keyboard options dialog window -->

--- a/capplets/network/mate-network-properties.ui
+++ b/capplets/network/mate-network-properties.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-network-properties -->
   <!-- interface-description network properties dialog window -->

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ MSD_REQUIRED=1.23.1
 MATEKBD_REQUIRED=1.17.0
 MATE_DESKTOP_REQUIRED=1.23.2
 APPINDICATOR_REQUIRED=0.0.13
+LIBWNCK_REQUIRED=3.0.0
 
 ENGINES_FOLDER="theming-engines"
 
@@ -154,6 +155,13 @@ GTK_ENGINE_DIR="$gtk_lib_dir/gtk-3.0/$gtk_binary_version/$ENGINES_FOLDER"
 AC_SUBST(GTK_ENGINE_DIR)
 
 PKG_CHECK_MODULES(GLIB, glib-2.0 >= $GLIB_REQUIRED $GMODULE_ADD)
+
+dnl -- check for libwnck (required) -------------------------------------------
+PKG_CHECK_MODULES(LIBWNCK, libwnck-3.0 >= $LIBWNCK_REQUIRED,,
+	AC_MSG_ERROR([libwnck is required to build mate-control-center.], 1))
+
+AC_SUBST(LIBWNCK_CFLAGS)
+AC_SUBST(LIBWNCK_LIBS)
 
 dnl
 dnl Check dependencies of libmate-slab


### PR DESCRIPTION
Hi,

I want to fix #474 because i'm completly agree with the author.

I'm not familiar with edits of 'Makefile.am' and 'configure.ac' files.

I have changed the 'capplets/Makefile.am' file only for test purpose.

Based from the code on this page : https://developer.gnome.org/libwnck/stable/getting-started.html

The idea is to search a window with the same title of the capplet launched and close it if the window already exists.

Tested with success just with 'mate-about-me' to know if is the right way.

Can someone give me feedback please?

Thanks by advance.
Regards.