### PR TITLE
Add tab scrolling support for GTK3

### DIFF
--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -138,6 +138,8 @@ main (int argc, char **argv)
 {
   AppearanceData *data;
   GtkWidget *w;
+  GtkWidget *nb;
+  GtkWidget *nb_custom_theme;
   GtkStyleContext *context;
 
   gchar *install_filename = NULL;
@@ -204,9 +206,9 @@ main (int argc, char **argv)
   if (wallpaper_files && !install_filename && !start_page)
     start_page = g_strdup ("background");
 
-  GtkNotebook* nb = GTK_NOTEBOOK(appearance_capplet_get_widget (data, "main_notebook"));
-  gtk_widget_add_events (GTK_WIDGET (nb), GDK_SCROLL_MASK);
-  g_signal_connect (GTK_WIDGET (nb), "scroll-event",
+  nb = appearance_capplet_get_widget (data, "main_notebook");
+  gtk_widget_add_events (nb, GDK_SCROLL_MASK);
+  g_signal_connect (nb, "scroll-event",
                     G_CALLBACK (capplet_dialog_page_scroll_event_cb),
                     GTK_WINDOW (w));
 
@@ -219,10 +221,12 @@ main (int argc, char **argv)
     w = appearance_capplet_get_widget (data, page_name);
     if (w != NULL) {
       gint pindex;
+      GtkNotebook *notebook;
 
-      pindex = gtk_notebook_page_num (nb, w);
+      notebook = GTK_NOTEBOOK (nb);
+      pindex = gtk_notebook_page_num (notebook, w);
       if (pindex != -1)
-        gtk_notebook_set_current_page (nb, pindex);
+        gtk_notebook_set_current_page (notebook, pindex);
     }
     g_free (page_name);
   }
@@ -235,6 +239,12 @@ main (int argc, char **argv)
   }
 
   g_option_context_free (option_context);
+
+  nb_custom_theme = appearance_capplet_get_widget (data, "notebook2");
+  gtk_widget_add_events (nb_custom_theme, GDK_SCROLL_MASK);
+  g_signal_connect (nb_custom_theme, "scroll-event",
+                    G_CALLBACK (capplet_dialog_page_scroll_event_cb),
+                    GTK_WINDOW (w));
 
   /* start the mainloop */
   gtk_main ();

--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -298,6 +298,7 @@ main (int argc, char **argv)
     GError     *error = NULL;
     GtkBuilder *builder;
     GdkScreen  *screen;
+    GtkWidget  *nb;
     gchar      *str;
     const char *current_wm;
     int i;
@@ -341,6 +342,13 @@ main (int argc, char **argv)
 
     /* Window */
     dialog_win = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_win"));
+
+    /* Notebook */
+    nb = GTK_WIDGET (gtk_builder_get_object (builder, "nb"));
+    gtk_widget_add_events (nb, GDK_SCROLL_MASK);
+    g_signal_connect (nb, "scroll-event",
+                      G_CALLBACK (capplet_dialog_page_scroll_event_cb),
+                      GTK_WINDOW (dialog_win));
 
     /* Compositing manager */
     compositing_checkbutton = GTK_WIDGET (gtk_builder_get_object (builder, "compositing_checkbutton"));


### PR DESCRIPTION
I forgot mate-window-properties to handle his notebook and add mouse tab scrolling.

I forgot too a secondary notebook in mate-appearance-properties (customize theme window).