### PR TITLE
Remove unused variable from capplet_notebook_scroll_event_cb

### DIFF
--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -208,9 +208,10 @@ main (int argc, char **argv)
 
   nb = appearance_capplet_get_widget (data, "main_notebook");
   gtk_widget_add_events (nb, GDK_SCROLL_MASK);
-  g_signal_connect (nb, "scroll-event",
-                    G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                    GTK_WINDOW (w));
+  g_signal_connect (nb,
+                    "scroll-event",
+                    G_CALLBACK (capplet_notebook_scroll_event_cb),
+                    NULL);
 
   if (start_page != NULL) {
     gchar *page_name;
@@ -242,9 +243,10 @@ main (int argc, char **argv)
 
   nb_custom_theme = appearance_capplet_get_widget (data, "notebook2");
   gtk_widget_add_events (nb_custom_theme, GDK_SCROLL_MASK);
-  g_signal_connect (nb_custom_theme, "scroll-event",
-                    G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                    GTK_WINDOW (w));
+  g_signal_connect (nb_custom_theme,
+                    "scroll-event",
+                    G_CALLBACK (capplet_notebook_scroll_event_cb),
+                    NULL);
 
   /* start the mainloop */
   gtk_main ();

--- a/capplets/common/capplet-util.c
+++ b/capplets/common/capplet-util.c
@@ -171,7 +171,8 @@ capplet_file_delete_recursive (GFile *file, GError **error)
 }
 
 gboolean
-capplet_dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window)
+capplet_notebook_scroll_event_cb (GtkWidget      *widget,
+                                  GdkEventScroll *event)
 {
     GtkNotebook *notebook = GTK_NOTEBOOK (widget);
     GtkWidget *child, *event_widget, *action_widget;

--- a/capplets/common/capplet-util.h
+++ b/capplets/common/capplet-util.h
@@ -39,7 +39,7 @@
 void capplet_help (GtkWindow *parent, char const *section);
 void capplet_set_icon (GtkWidget *window, char const *icon_file_name);
 gboolean capplet_file_delete_recursive (GFile *directory, GError **error);
-gboolean capplet_dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window);
+gboolean capplet_notebook_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event);
 void capplet_init (GOptionContext *context, int *argc, char ***argv);
 
 #endif /* __CAPPLET_UTIL_H */

--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -789,9 +789,10 @@ show_dialog(MateDACapplet* capplet, const gchar* start_page)
 
         GtkNotebook* nb = GTK_NOTEBOOK(get_widget("preferred_apps_notebook"));
         gtk_widget_add_events (GTK_WIDGET (nb), GDK_SCROLL_MASK);
-        g_signal_connect (GTK_WIDGET (nb), "scroll-event",
-                          G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                          GTK_WINDOW (capplet->window));
+        g_signal_connect (GTK_WIDGET (nb),
+                          "scroll-event",
+                          G_CALLBACK (capplet_notebook_scroll_event_cb),
+                          NULL);
 
 	if (start_page != NULL)
 	{

--- a/capplets/keyboard/mate-keyboard-properties.c
+++ b/capplets/keyboard/mate-keyboard-properties.c
@@ -245,9 +245,10 @@ main (int argc, char **argv)
 
         GtkNotebook* nb = GTK_NOTEBOOK (WID ("keyboard_notebook"));
         gtk_widget_add_events (GTK_WIDGET (nb), GDK_SCROLL_MASK);
-        g_signal_connect (GTK_WIDGET (nb), "scroll-event",
-                          G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                          GTK_WINDOW (WID ("keyboard_dialog")));
+        g_signal_connect (GTK_WIDGET (nb),
+                          "scroll-event",
+                          G_CALLBACK (capplet_notebook_scroll_event_cb),
+                          NULL);
 
 	if (switch_to_typing_break_page) {
 		gtk_notebook_set_current_page (nb, 4);

--- a/capplets/mouse/mate-mouse-properties.c
+++ b/capplets/mouse/mate-mouse-properties.c
@@ -465,9 +465,10 @@ main (int argc, char **argv)
 
                 GtkNotebook* nb = GTK_NOTEBOOK (WID ("prefs_widget"));
                 gtk_widget_add_events (GTK_WIDGET (nb), GDK_SCROLL_MASK);
-                g_signal_connect (GTK_WIDGET (nb), "scroll-event",
-                                  G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                                  GTK_WINDOW (dialog_win));
+                g_signal_connect (GTK_WIDGET (nb),
+                                  "scroll-event",
+                                  G_CALLBACK (capplet_notebook_scroll_event_cb),
+                                  NULL);
 
 
 		if (start_page != NULL) {

--- a/capplets/network/mate-network-properties.c
+++ b/capplets/network/mate-network-properties.c
@@ -482,9 +482,10 @@ main (int argc, char **argv)
 
         GtkNotebook* nb = GTK_NOTEBOOK (_gtk_builder_get_widget (builder, "notebook1"));
         gtk_widget_add_events (GTK_WIDGET (nb), GDK_SCROLL_MASK);
-        g_signal_connect (GTK_WIDGET (nb), "scroll-event",
-                          G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                          GTK_WINDOW (widget));
+        g_signal_connect (GTK_WIDGET (nb),
+                          "scroll-event",
+                          G_CALLBACK (capplet_notebook_scroll_event_cb),
+                          NULL);
 
 	capplet_set_icon (widget, "network-server");
 	gtk_widget_show_all (widget);

--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -346,9 +346,10 @@ main (int argc, char **argv)
     /* Notebook */
     nb = GTK_WIDGET (gtk_builder_get_object (builder, "nb"));
     gtk_widget_add_events (nb, GDK_SCROLL_MASK);
-    g_signal_connect (nb, "scroll-event",
-                      G_CALLBACK (capplet_dialog_page_scroll_event_cb),
-                      GTK_WINDOW (dialog_win));
+    g_signal_connect (nb,
+                      "scroll-event",
+                      G_CALLBACK (capplet_notebook_scroll_event_cb),
+                      NULL);
 
     /* Compositing manager */
     compositing_checkbutton = GTK_WIDGET (gtk_builder_get_object (builder, "compositing_checkbutton"));


### PR DESCRIPTION
Based on:
- https://github.com/mate-desktop/mate-terminal/commit/8d2eb0898154f2624e2ae34039169f307a3411a5
- https://github.com/mate-desktop/mate-terminal/commit/622e2d1272bf2d7a99d147482ae6a51b0a77f188