### PR TITLE
Remove unused macros

### DIFF
--- a/capplets/common/mate-theme-apply.c
+++ b/capplets/common/mate-theme-apply.c
@@ -31,7 +31,6 @@
 #define GTK_THEME_KEY           "gtk-theme"
 #define COLOR_SCHEME_KEY        "gtk-color-scheme"
 #define ICON_THEME_KEY          "icon-theme"
-#define FONT_KEY                "font-name"
 
 #define MARCO_SCHEMA            "org.mate.Marco.general"
 #define MARCO_THEME_KEY         "theme"

--- a/capplets/common/mate-theme-info.c
+++ b/capplets/common/mate-theme-info.c
@@ -50,7 +50,6 @@
 #define CURSOR_THEME_KEY "X-GNOME-Metatheme/CursorTheme"
 #define NOTIFICATION_THEME_KEY "X-GNOME-Metatheme/NotificationTheme"
 #define CURSOR_SIZE_KEY "X-GNOME-Metatheme/CursorSize"
-#define SOUND_THEME_KEY "X-GNOME-Metatheme/SoundTheme"
 #define APPLICATION_FONT_KEY "X-GNOME-Metatheme/ApplicationFont"
 #define DOCUMENTS_FONT_KEY "X-GNOME-Metatheme/DocumentsFont"
 #define DESKTOP_FONT_KEY "X-GNOME-Metatheme/DesktopFont"

--- a/capplets/keybindings/eggcellrendererkeys.c
+++ b/capplets/keybindings/eggcellrendererkeys.c
@@ -1,20 +1,11 @@
 #include <config.h>
-#include <libintl.h>
+#include <glib.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include "eggcellrendererkeys.h"
 #include "eggaccelerators.h"
-
-#ifndef EGG_COMPILATION
-	#ifndef _
-		#define _(x) dgettext (GETTEXT_PACKAGE, x)
-		#define N_(x) x
-	#endif
-#else
-	#define _(x) x
-	#define N_(x) x
-#endif
 
 #define EGG_CELL_RENDERER_TEXT_PATH "egg-cell-renderer-text"
 

--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -40,10 +40,7 @@
 #include "capplet-util.h"
 
 #define MARCO_SCHEMA "org.mate.Marco.general"
-#define MARCO_THEME_KEY "theme"
-#define MARCO_FONT_KEY  "titlebar-font"
 #define MARCO_FOCUS_KEY "focus-mode"
-#define MARCO_USE_SYSTEM_FONT_KEY "titlebar-uses-system-font"
 #define MARCO_AUTORAISE_KEY "auto-raise"
 #define MARCO_AUTORAISE_DELAY_KEY "auto-raise-delay"
 #define MARCO_MOUSE_MODIFIER_KEY "mouse-button-modifier"

--- a/font-viewer/font-view.c
+++ b/font-viewer/font-view.c
@@ -95,7 +95,6 @@ static const gchar *app_menu =
     "  <menu>"
     "</interface>";
 
-#define VIEW_ITEM_WIDTH 140
 #define VIEW_ITEM_WRAP_WIDTH 128
 #define VIEW_COLUMN_SPACING 36
 #define VIEW_MARGIN 16

--- a/libslab/app-shell.c
+++ b/libslab/app-shell.c
@@ -45,7 +45,6 @@
 #include "themed-icon.h"
 
 #define TILE_EXEC_NAME "Tile_desktop_exec_name"
-#define SECONDS_IN_DAY 86400
 #define CC_SCHEMA "org.mate.control-center"
 #define EXIT_SHELL_ON_ACTION_START "cc-exit-shell-on-action-start"
 #define EXIT_SHELL_ON_ACTION_HELP "cc-exit-shell-on-action-help"

--- a/libslab/shell-window.c
+++ b/libslab/shell-window.c
@@ -25,8 +25,6 @@
 
 #include "app-resizer.h"
 
-#define SHELL_WINDOW_BORDER_WIDTH 6
-
 G_DEFINE_TYPE (ShellWindow, shell_window, GTK_TYPE_FRAME);
 
 static void

--- a/libwindow-settings/marco-window-manager.c
+++ b/libwindow-settings/marco-window-manager.c
@@ -36,7 +36,6 @@
 #define MARCO_THEME_KEY "theme"
 #define MARCO_FONT_KEY  "titlebar-font"
 #define MARCO_FOCUS_KEY "focus-mode"
-#define MARCO_USE_SYSTEM_FONT_KEY "titlebar-uses-system-font"
 #define MARCO_AUTORAISE_KEY "auto-raise"
 #define MARCO_AUTORAISE_DELAY_KEY "auto-raise-delay"
 #define MARCO_MOUSE_MODIFIER_KEY "mouse-button-modifier"

--- a/typing-break/drwright.c
+++ b/typing-break/drwright.c
@@ -49,9 +49,6 @@
 #define BLINK_TIMEOUT_FACTOR 100
 #endif /* HAVE_APP_INDICATOR */
 
-#define POPUP_ITEM_ENABLED 1
-#define POPUP_ITEM_BREAK   2
-
 typedef enum {
 	STATE_START,
 	STATE_RUNNING,


### PR DESCRIPTION
```
marco-window-manager.c:39: warning: macro "MARCO_USE_SYSTEM_FONT_KEY" is not used [-Wunused-macros]
   39 | #define MARCO_USE_SYSTEM_FONT_KEY "titlebar-uses-system-font"
--
mate-theme-apply.c:34: warning: macro "FONT_KEY" is not used [-Wunused-macros]
   34 | #define FONT_KEY                "font-name"
--
mate-theme-info.c:53: warning: macro "SOUND_THEME_KEY" is not used [-Wunused-macros]
   53 | #define SOUND_THEME_KEY "X-GNOME-Metatheme/SoundTheme"
--
foo-marshal.c:3: warning: macro "__FOO_MARSHAL_MARSHAL_H__" is not used [-Wunused-macros]
    3 | #define __FOO_MARSHAL_MARSHAL_H__
--
eggcellrendererkeys.c:12: warning: macro "N_" is not used [-Wunused-macros]
   12 |   #define N_(x) x
--
mate-window-properties.c:43: warning: macro "MARCO_THEME_KEY" is not used [-Wunused-macros]
   43 | #define MARCO_THEME_KEY "theme"
--
mate-window-properties.c:44: warning: macro "MARCO_FONT_KEY" is not used [-Wunused-macros]
   44 | #define MARCO_FONT_KEY  "titlebar-font"
--
mate-window-properties.c:46: warning: macro "MARCO_USE_SYSTEM_FONT_KEY" is not used [-Wunused-macros]
   46 | #define MARCO_USE_SYSTEM_FONT_KEY "titlebar-uses-system-font"
--
font-view.c:98: warning: macro "VIEW_ITEM_WIDTH" is not used [-Wunused-macros]
   98 | #define VIEW_ITEM_WIDTH 140
app-shell.c:48: warning: macro "SECONDS_IN_DAY" is not used [-Wunused-macros]
   48 | #define SECONDS_IN_DAY 86400
--
shell-window.c:28: warning: macro "SHELL_WINDOW_BORDER_WIDTH" is not used [-Wunused-macros]
   28 | #define SHELL_WINDOW_BORDER_WIDTH 6
--
drwright.c:53: warning: macro "POPUP_ITEM_BREAK" is not used [-Wunused-macros]
   53 | #define POPUP_ITEM_BREAK   2
--
drwright.c:52: warning: macro "POPUP_ITEM_ENABLED" is not used [-Wunused-macros]
   52 | #define POPUP_ITEM_ENABLED 1

```