### PR TITLE
about-me: avoid cast from non-struct type to struct type

### DIFF
--- a/capplets/about-me/mate-about-me-fingerprint.c
+++ b/capplets/about-me/mate-about-me-fingerprint.c
@@ -732,9 +732,9 @@ enroll_fingerprints (GtkWindow *parent, GtkWidget *enable, GtkWidget *disable)
 		g_variant_get (ret, "(a{sv})", &iter);
 		while (g_variant_iter_loop (iter, "{sv}", &key, &value))
 		{
-			if (g_str_equal (key, "name") && g_variant_get_type (value) == G_VARIANT_TYPE_STRING) {
+			if (g_str_equal (key, "name") && g_variant_get_type (value) == G_VARIANT_TYPE((gpointer) "(s)")) {
 				data->name = g_strdup (g_variant_get_string (value, NULL));
-			} else if (g_str_equal (key, "scan-type") && g_variant_get_type (value) == G_VARIANT_TYPE_STRING) {
+			} else if (g_str_equal (key, "scan-type") && g_variant_get_type (value) == G_VARIANT_TYPE((gpointer) "(s)")) {
 				if (g_str_equal (g_variant_get_string (value, NULL), "swipe"))
 					data->is_swipe = TRUE;
 			}


### PR DESCRIPTION
Fixes the warnings:

```
mate-about-me-fingerprint.c:735:67: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
                        if (g_str_equal (key, "name") && g_variant_get_type (value) == G_VARIANT_TYPE_STRING) {
                                                                                       ^~~~~~~~~~~~~~~~~~~~~

mate-about-me-fingerprint.c:737:79: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
                        } else if (g_str_equal (key, "scan-type") && g_variant_get_type (value) == G_VARIANT_TYPE_STRING) {
                                                                                                   ^~~~~~~~~~~~~~~~~~~~~
```