### PR TITLE
Default applications: Add flac format for media

### DIFF
--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -100,6 +100,7 @@ set_changed(GtkComboBox* combo, MateDACapplet* capplet, GList* list, gint type)
 				break;
 
 			case DA_TYPE_MEDIA:
+				g_app_info_set_as_default_for_type(item, "audio/flac", NULL);
 				g_app_info_set_as_default_for_type(item, "audio/mpeg", NULL);
 				g_app_info_set_as_default_for_type(item, "audio/x-mpegurl", NULL);
 				g_app_info_set_as_default_for_type(item, "audio/x-scpls", NULL);

--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -101,6 +101,7 @@ set_changed(GtkComboBox* combo, MateDACapplet* capplet, GList* list, gint type)
 
 			case DA_TYPE_MEDIA:
 				g_app_info_set_as_default_for_type(item, "audio/flac", NULL);
+				g_app_info_set_as_default_for_type(item, "audio/x-flac", NULL);
 				g_app_info_set_as_default_for_type(item, "audio/mpeg", NULL);
 				g_app_info_set_as_default_for_type(item, "audio/x-mpegurl", NULL);
 				g_app_info_set_as_default_for_type(item, "audio/x-scpls", NULL);


### PR DESCRIPTION
From the default applications menu I changed the default application for audio, but didn't work for [FLAC](https://en.wikipedia.org/wiki/FLAC) audio files. This pull requests aims to solve that.

**Important**: I didn't compile it to test that it works, I have no experience with C and I got an error when I tried to execute `.autogen.sh`, I hope you can help me with your feedback if my changes don't work:

<pre><samp>
$ ACLOCAL_FLAGS="-I /usr/share/aclocal -I /usr/local/share/aclocal" ./autogen.sh
/usr/bin/mate-autogen
You need to install yelp-tools
checking for autoreconf >= 2.53...
  testing autoreconf... found 2.69
checking for pkg-config >= 0.14.0...
  testing pkg-config... found 0.29.1
checking for mate-common >= 1.1.0...
  testing mate-doc-common... found 1.24.0
Checking for required M4 macros...
  yelp.m4 not found
***Error***: some autoconf macros required to build mate-control-center
  were not found in your aclocal path, or some forbidden
  macros were found.  Perhaps you need to adjust your
  ACLOCAL_FLAGS?
</samp></pre>
