### PR TITLE
application-tile: warning -Wempty-body

### DIFF
--- a/libslab/application-tile.c
+++ b/libslab/application-tile.c
@@ -628,8 +628,9 @@ update_user_list_menu_item (ApplicationTile *this)
 
 		gtk_widget_show_all (item);
 	}
-	else
+	else {
 		/* do nothing */ ;
+	}
 
 	action = TILE (this)->actions [APPLICATION_TILE_ACTION_UPDATE_MAIN_MENU];
 


### PR DESCRIPTION
```
application-tile.c: In function 'update_user_list_menu_item':
application-tile.c:632:20: warning: suggest braces around empty body in an 'else' statement [-Wempty-body]
  632 |   /* do nothing */ ;
      |                    ^
```