### PR TITLE
xrandr-capplet: warning -Wincompatible-pointer-types

### DIFF
--- a/capplets/display/xrandr-capplet.c
+++ b/capplets/display/xrandr-capplet.c
@@ -2500,7 +2500,7 @@ restart:
 	break;
 
     case GTK_RESPONSE_HELP:
-        gtk_show_uri_on_window (GTK_DIALOG (app->dialog),
+        gtk_show_uri_on_window (GTK_WINDOW (app->dialog),
                                 "help:mate-user-guide/goscustdesk-70",
                                 gtk_get_current_event_time (),
                                 &error);


### PR DESCRIPTION
```
xrandr-capplet.c: In function 'run_application':
/usr/include/glib-2.0/gobject/gtype.h:2297:6: warning: passing argument 1 of 'gtk_show_uri_on_window' from incompatible pointer type [-Wincompatible-pointer-types]
 2297 |     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
/usr/include/glib-2.0/gobject/gtype.h:484:66: note: in expansion of macro '_G_TYPE_CIC'
  484 | #define G_TYPE_CHECK_INSTANCE_CAST(instance, g_type, c_type)    (_G_TYPE_CIC ((instance), (g_type), c_type))
      |                                                                  ^~~~~~~~~~~
/usr/include/gtk-3.0/gtk/gtkdialog.h:90:43: note: in expansion of macro 'G_TYPE_CHECK_INSTANCE_CAST'
   90 | #define GTK_DIALOG(obj)                  (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_DIALOG, GtkDialog))
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
xrandr-capplet.c:2503:33: note: in expansion of macro 'GTK_DIALOG'
 2503 |         gtk_show_uri_on_window (GTK_DIALOG (app->dialog),
      |                                 ^~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:200,
                 from xrandr-capplet.c:27:
/usr/include/gtk-3.0/gtk/gtkshow.h:39:47: note: expected 'GtkWindow *' {aka 'struct _GtkWindow *'} but argument is of type 'GtkDialog *' {aka 'struct _GtkDialog *'}
   39 | gboolean gtk_show_uri_on_window (GtkWindow   *parent,
      |                                  ~~~~~~~~~~~~~^~~~~~
```