### PR TITLE
Revisit windows applet, add allow-top-tiling option

### DIFF
--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -43,6 +43,7 @@
 
 #define MARCO_CENTER_NEW_WINDOWS_KEY "center-new-windows"
 #define MARCO_ALLOW_TILING_KEY "allow-tiling"
+#define MARCO_ALLOW_TOP_TILING_KEY "allow-top-tiling"
 #define MARCO_SHOW_TAB_BORDER_KEY "show-tab-border"
 #define MARCO_BUTTON_LAYOUT_KEY "button-layout"
 #define MARCO_DOUBLE_CLICK_TITLEBAR_KEY "action-double-click-titlebar"
@@ -88,18 +89,22 @@ typedef struct
 
 static GtkWidget *dialog_win;
 
-/* General */
-static GtkWidget *center_new_windows_checkbutton;
-static GtkWidget *allow_tiling_checkbutton;
+/* Behaviour */
 static GtkWidget *show_tab_border_checkbutton;
-static GtkWidget *titlebar_layout_optionmenu;
 static GtkWidget *double_click_titlebar_optionmenu;
 static GtkWidget *focus_mode_checkbutton;
 static GtkWidget *focus_mode_mouse_checkbutton;
 static GtkWidget *autoraise_checkbutton;
 static GtkWidget *autoraise_delay_spinbutton;
+static GtkWidget *autoraise_delay_hbox;
 static GtkWidget *reduced_resources_checkbutton;
 static GtkWidget *alt_click_vbox;
+
+/* Placement */
+static GtkWidget *center_new_windows_checkbutton;
+static GtkWidget *enable_tiling_checkbutton;
+static GtkWidget *allow_top_tiling_checkbutton;
+static GtkWidget *titlebar_layout_optionmenu;
 
 /* Compositing Manager */
 static GtkWidget *compositing_checkbutton;
@@ -119,11 +124,14 @@ update_sensitivity (void)
 
     gtk_widget_set_sensitive (compositing_fast_alt_tab_checkbutton,
                               g_settings_get_boolean (marco_settings, MARCO_COMPOSITING_MANAGER_KEY));
-    gtk_widget_set_sensitive (allow_tiling_checkbutton,
+    gtk_widget_set_sensitive (enable_tiling_checkbutton,
                               !g_settings_get_boolean (marco_settings, MARCO_REDUCED_RESOURCES_KEY));
+    gtk_widget_set_sensitive (allow_top_tiling_checkbutton,
+                              g_settings_get_boolean (marco_settings, MARCO_ALLOW_TILING_KEY) &&
+                             !g_settings_get_boolean (marco_settings, MARCO_REDUCED_RESOURCES_KEY));
     gtk_widget_set_sensitive (focus_mode_mouse_checkbutton,
                               g_settings_get_enum (marco_settings, MARCO_FOCUS_KEY) != FOCUS_MODE_CLICK);
-    gtk_widget_set_sensitive (autoraise_checkbutton,
+    gtk_widget_set_sensitive (autoraise_delay_hbox,
                               g_settings_get_enum (marco_settings, MARCO_FOCUS_KEY) != FOCUS_MODE_CLICK);
     gtk_widget_set_sensitive (autoraise_delay_spinbutton,
                               g_settings_get_enum (marco_settings, MARCO_FOCUS_KEY) != FOCUS_MODE_CLICK &&
@@ -352,18 +360,22 @@ main (int argc, char **argv)
                       G_CALLBACK (capplet_notebook_scroll_event_cb),
                       NULL);
 
-    /* General */
-    center_new_windows_checkbutton = GET_WIDGET ("center_new_windows_checkbutton");
-    allow_tiling_checkbutton = GET_WIDGET ("allow_tiling_checkbutton");
+    /* Behaviour */
     show_tab_border_checkbutton = GET_WIDGET ("show_tab_border_checkbutton");
-    titlebar_layout_optionmenu = GET_WIDGET ("titlebar_layout_optionmenu");
     double_click_titlebar_optionmenu = GET_WIDGET ("double_click_titlebar_optionmenu");
     focus_mode_checkbutton = GET_WIDGET ("focus_mode_checkbutton");
     focus_mode_mouse_checkbutton = GET_WIDGET ("focus_mode_mouse_checkbutton");
+    autoraise_delay_hbox = GET_WIDGET ("autoraise_delay_hbox");
     autoraise_checkbutton = GET_WIDGET ("autoraise_checkbutton");
     autoraise_delay_spinbutton = GET_WIDGET ("autoraise_delay_spinbutton");
     reduced_resources_checkbutton = GET_WIDGET ("reduced_resources_checkbutton");
     alt_click_vbox = GET_WIDGET ("alt_click_vbox");
+
+    /* Placement */
+    center_new_windows_checkbutton = GET_WIDGET ("center_new_windows_checkbutton");
+    enable_tiling_checkbutton = GET_WIDGET ("enable_tiling_checkbutton");
+    allow_top_tiling_checkbutton = GET_WIDGET ("allow_top_tiling_checkbutton");
+    titlebar_layout_optionmenu = GET_WIDGET ("titlebar_layout_optionmenu");
 
     /* Composition Manager */
     compositing_checkbutton = GET_WIDGET ("compositing_checkbutton");
@@ -391,19 +403,7 @@ main (int argc, char **argv)
     gtk_combo_box_set_active (GTK_COMBO_BOX (double_click_titlebar_optionmenu),
                               g_settings_get_enum (marco_settings, MARCO_DOUBLE_CLICK_TITLEBAR_KEY));
 
-    /* General */
-    g_settings_bind (marco_settings,
-                     MARCO_CENTER_NEW_WINDOWS_KEY,
-                     center_new_windows_checkbutton,
-                     "active",
-                     G_SETTINGS_BIND_DEFAULT);
-
-    g_settings_bind (marco_settings,
-                     MARCO_ALLOW_TILING_KEY,
-                     allow_tiling_checkbutton,
-                     "active",
-                     G_SETTINGS_BIND_DEFAULT);
-
+    /* Behaviour */
     g_settings_bind (marco_settings,
                      MARCO_SHOW_TAB_BORDER_KEY,
                      show_tab_border_checkbutton,
@@ -413,6 +413,25 @@ main (int argc, char **argv)
     g_settings_bind (marco_settings,
                      MARCO_REDUCED_RESOURCES_KEY,
                      reduced_resources_checkbutton,
+                     "active",
+                     G_SETTINGS_BIND_DEFAULT);
+
+    /* Placement */
+    g_settings_bind (marco_settings,
+                     MARCO_CENTER_NEW_WINDOWS_KEY,
+                     center_new_windows_checkbutton,
+                     "active",
+                     G_SETTINGS_BIND_DEFAULT);
+
+    g_settings_bind (marco_settings,
+                     MARCO_ALLOW_TILING_KEY,
+                     enable_tiling_checkbutton,
+                     "active",
+                     G_SETTINGS_BIND_DEFAULT);
+
+    g_settings_bind (marco_settings,
+                     MARCO_ALLOW_TOP_TILING_KEY,
+                     allow_top_tiling_checkbutton,
                      "active",
                      G_SETTINGS_BIND_DEFAULT);
 

--- a/capplets/windows/window-properties.ui
+++ b/capplets/windows/window-properties.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.1 
+<!-- Generated with glade 3.38.2 
 
 window-properties.ui - MATE window properties dialog
 Copyright (C) MATE Developers
@@ -31,7 +31,7 @@ Author: Robert Buj
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step-increment">0.1</property>
+    <property name="step-increment">0.10</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkImage" id="image_help_browser">
@@ -108,188 +108,12 @@ Author: Robert Buj
             <property name="can-focus">True</property>
             <property name="border-width">6</property>
             <child>
-              <object class="GtkBox" id="windows_vbox">
+              <object class="GtkBox" id="behaviour_vbox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
-                <child>
-                  <object class="GtkBox" id="position_and_behaviour_main_vbox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel" id="position_and_behavior_label">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Position and Behaviour</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="position_and_behavior_vbox">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-start">6</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkCheckButton" id="center_new_windows_checkbutton">
-                            <property name="label" translatable="yes">Center _new windows</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="allow_tiling_checkbutton">
-                            <property name="label" translatable="yes">Enable window _tiling</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="show_tab_border_checkbutton">
-                            <property name="label" translatable="yes">Show window border in Alt-Tab</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="position_of_titlebar_buttons_hbox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkLabel" id="position_of_titlebar_buttons_label">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">_Position of titlebar buttons:</property>
-                                <property name="use-underline">True</property>
-                                <property name="mnemonic-widget">titlebar_layout_optionmenu</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBoxText" id="titlebar_layout_optionmenu">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <items>
-                                  <item translatable="yes">Right</item>
-                                  <item translatable="yes">Left</item>
-                                </items>
-                                <signal name="changed" handler="on_titlebar_layout_optionmenu_changed" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">7</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="double_click_titlebar_action_hbox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkLabel" id="double_click_titlebar_label">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">_Double-click titlebar action:</property>
-                                <property name="use-underline">True</property>
-                                <property name="mnemonic-widget">double_click_titlebar_optionmenu</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBoxText" id="double_click_titlebar_optionmenu">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <items>
-                                  <item translatable="yes">Roll up</item>
-                                  <item translatable="yes">Maximize</item>
-                                  <item translatable="yes">Maximize Horizontally</item>
-                                  <item translatable="yes">Maximize Vertically</item>
-                                  <item translatable="yes">Minimize</item>
-                                  <item translatable="yes">None</item>
-                                </items>
-                                <signal name="changed" handler="on_double_click_titlebar_optionmenu_changed" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">8</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkBox" id="window_selection_main_vbox">
                     <property name="visible">True</property>
@@ -379,7 +203,7 @@ Author: Robert Buj
                                 <property name="can-focus">True</property>
                                 <property name="text" translatable="yes">1,0</property>
                                 <property name="adjustment">adjustment1</property>
-                                <property name="climb-rate">0.1</property>
+                                <property name="climb-rate">0.10</property>
                                 <property name="digits">1</property>
                                 <property name="snap-to-ticks">True</property>
                                 <property name="numeric">True</property>
@@ -393,7 +217,7 @@ Author: Robert Buj
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel">
+                              <object class="GtkLabel" id="seconds_label">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">seconds</property>
@@ -422,7 +246,154 @@ Author: Robert Buj
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="titlebar_action_main_vbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="titlebar_action_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Titlebar Action</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="titlebar_action_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkBox" id="double_click_titlebar_action_hbox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="double_click_titlebar_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">_Double-click titlebar action:</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">double_click_titlebar_optionmenu</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBoxText" id="double_click_titlebar_optionmenu">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <items>
+                                  <item translatable="yes">Roll up</item>
+                                  <item translatable="yes">Maximize</item>
+                                  <item translatable="yes">Maximize Horizontally</item>
+                                  <item translatable="yes">Maximize Vertically</item>
+                                  <item translatable="yes">Minimize</item>
+                                  <item translatable="yes">None</item>
+                                </items>
+                                <signal name="changed" handler="on_double_click_titlebar_optionmenu_changed" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">8</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="alt_tab_main_vbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="alt_tab_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Alt-Tab</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="position_and_behavior_vbox3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkCheckButton" id="show_tab_border_checkbutton">
+                            <property name="label" translatable="yes">Show window border in _Alt-Tab</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -456,7 +427,7 @@ Author: Robert Buj
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="reduced_resources_checkbutton">
-                            <property name="label" translatable="yes">Use reduced resources</property>
+                            <property name="label" translatable="yes">Use _reduced resources</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -480,7 +451,7 @@ Author: Robert Buj
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -490,7 +461,7 @@ Author: Robert Buj
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkLabel" id="movement_key__label">
+                      <object class="GtkLabel" id="movement_key_label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
@@ -513,7 +484,7 @@ Author: Robert Buj
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="movement_description_label">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="label" translatable="yes">To move a window, press-and-hold this key then grab the window:</property>
@@ -551,18 +522,259 @@ Author: Robert Buj
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>
             </child>
             <child type="tab">
-              <object class="GtkLabel" id="general_label">
+              <object class="GtkLabel" id="behaviour_label">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">General</property>
+                <property name="label" translatable="yes">Behaviour</property>
               </object>
               <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="placement_vbox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">18</property>
+                <child>
+                  <object class="GtkBox" id="new_windows_main_vbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="new_windows_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">New Windows</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="center_new_windows_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkCheckButton" id="center_new_windows_checkbutton">
+                            <property name="label" translatable="yes">Centre _new windows</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="window_snapping_main_vbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="window_snapping_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Window Snapping</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="window_snapping_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkCheckButton" id="enable_tiling_checkbutton">
+                            <property name="label" translatable="yes">Enable window _tiling</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="allow_top_tiling_checkbutton">
+                            <property name="label" translatable="yes">Allow _top tiling</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="margin-start">12</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="titlebar_buttons_main_vbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="titlebar_buttons_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Titlebar Buttons</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="titlebar_buttons_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkBox" id="position_of_titlebar_buttons_hbox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="position_of_titlebar_buttons_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">_Position of titlebar buttons:</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">titlebar_layout_optionmenu</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBoxText" id="titlebar_layout_optionmenu">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <items>
+                                  <item translatable="yes">Right</item>
+                                  <item translatable="yes">Left</item>
+                                </items>
+                                <signal name="changed" handler="on_titlebar_layout_optionmenu_changed" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="placement_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Placement</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>
@@ -649,7 +861,7 @@ Author: Robert Buj
                 </child>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child type="tab">
@@ -659,7 +871,7 @@ Author: Robert Buj
                 <property name="label" translatable="yes">Compositing Manager</property>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">2</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>
@@ -676,11 +888,5 @@ Author: Robert Buj
       <action-widget response="-11">button_help_browser</action-widget>
       <action-widget response="-7">button_window_close</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkSizeGroup" id="sizegroup_position_behaviour">
-    <widgets>
-      <widget name="position_of_titlebar_buttons_label"/>
-      <widget name="double_click_titlebar_label"/>
-    </widgets>
   </object>
 </interface>


### PR DESCRIPTION
The design is more similar to the original now.
Adds allow-top-tiling option, which is insensitive if use-reduced-resources is true or if allow-tiling (Enable window tiling) is false.

![Screenshot at 2020-11-27 12-22-00](https://user-images.githubusercontent.com/39454100/100445014-b0951300-30ac-11eb-8e9c-723d9012aa5f.png)
![Screenshot at 2020-11-27 12-22-20](https://user-images.githubusercontent.com/39454100/100445023-b4c13080-30ac-11eb-8e81-8805b798924c.png)
![Screenshot at 2020-11-27 12-22-29](https://user-images.githubusercontent.com/39454100/100445028-b68af400-30ac-11eb-9979-4770bd1217f6.png)
