### PR TITLE
build: show the package version in the configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,7 +311,10 @@ dnl - Show summary
 dnl ---------------------------------------------------------------------------
 
 echo "
-              mate-control-center
+Configure summary:
+
+        ${PACKAGE_STRING}
+        `echo $PACKAGE_STRING | sed "s/./=/g"`
 
         Compiler:              ${CC}
         Compiler flags:        ${CFLAGS}


### PR DESCRIPTION
Test:
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

        mate-control-center 1.25.0
        ==========================

        Compiler:              gcc
        Compiler flags:        
        Warning flags:         -Wall -Wmissing-prototypes
        Linker flags:          

        Appindicator:          yes
        Libmate-slab:          yes
        Accountsservice:       yes

Now type `make' to compile mate-control-center
```