### PR TITLE
common: missing include gtkrc-utils.h

### DIFF
--- a/capplets/common/gtkrc-utils.c
+++ b/capplets/common/gtkrc-utils.c
@@ -30,6 +30,8 @@
 #include <fcntl.h>
 #include <gtk/gtk.h>
 
+#include "gtkrc-utils.h"
+
 #define INCLUDE_SYMBOL ((gpointer) 1)
 #define ENGINE_SYMBOL ((gpointer) 2)
 #define COLOR_SCHEME_SYMBOL ((gpointer) 3)


### PR DESCRIPTION
Fix the warnings below:
```
gtkrc-utils.c:37:8: warning: no previous prototype for ‘gtkrc_find_named’ [-Wmissing-prototypes]
gtkrc-utils.c:82:6: warning: no previous prototype for ‘gtkrc_get_details’ [-Wmissing-prototypes]
gtkrc-utils.c:179:1: warning: no previous prototype for ‘gtkrc_get_color_scheme’ [-Wmissing-prototypes]
gtkrc-utils.c:243:8: warning: no previous prototype for ‘gtkrc_get_color_scheme_for_theme’ [-Wmissing-prototypes]
```