### PR TITLE
windows: missing include mate-metacity-support.h

### DIFF
--- a/capplets/windows/mate-metacity-support.c
+++ b/capplets/windows/mate-metacity-support.c
@@ -23,6 +23,8 @@
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
+#include "mate-metacity-support.h"
+
 #define METACITY_SCHEMA "org.gnome.metacity"
 #define COMPOSITING_KEY "compositing-manager"
 


### PR DESCRIPTION
Fix the warning below:
```
mate-metacity-support.c:30:1: warning: no previous prototype for ‘mate_metacity_config_tool’ [-Wmissing-prototypes]
```