### PR TITLE
appearance: -Wmissing-prototypes warnings

### DIFF
--- a/capplets/appearance/appearance-desktop.c
+++ b/capplets/appearance/appearance-desktop.c
@@ -607,7 +607,7 @@ wp_props_wp_selected (GtkTreeSelection *selection,
   }
 }
 
-void
+static void
 wp_create_filechooser (AppearanceData *data)
 {
   const char *start_dir, *pictures = NULL;

--- a/capplets/appearance/appearance-desktop.c
+++ b/capplets/appearance/appearance-desktop.c
@@ -24,6 +24,8 @@
 #include "mate-wp-info.h"
 #include "mate-wp-item.h"
 #include "mate-wp-xml.h"
+#include "appearance-desktop.h"
+
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <string.h>

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -31,6 +31,7 @@
 #include <glib/gstdio.h>
 
 #include "capplet-util.h"
+#include "appearance-font.h"
 
 /* X servers sometimes lie about the screen's physical dimensions, so we cannot
  * compute an accurate DPI value.  When this happens, the user gets fonts that

--- a/capplets/appearance/appearance-style.c
+++ b/capplets/appearance/appearance-style.c
@@ -17,6 +17,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
 #include "appearance.h"
 
 #include <string.h>
@@ -28,6 +29,7 @@
 #include "gtkrc-utils.h"
 #include "theme-thumbnail.h"
 #include "capplet-util.h"
+#include "appearance-style.h"
 
 #define GSETTINGS_SETTINGS "GSETTINGS_SETTINGS"
 #define GSETTINGS_KEY      "GSETTINGS_KEY"

--- a/capplets/appearance/appearance-support.c
+++ b/capplets/appearance/appearance-support.c
@@ -20,6 +20,7 @@
 
 #include "appearance.h"
 #include "wm-common.h"
+#include "appearance-support.h"
 
 #include <glib.h>
 #include <gio/gio.h>

--- a/capplets/appearance/appearance-themes.c
+++ b/capplets/appearance/appearance-themes.c
@@ -26,6 +26,7 @@
 #include "theme-save.h"
 #include "theme-util.h"
 #include "gtkrc-utils.h"
+#include "appearance-themes.h"
 
 #include <glib/gi18n.h>
 #include <libwindow-settings/mate-wm-manager.h>

--- a/capplets/appearance/appearance-ui.c
+++ b/capplets/appearance/appearance-ui.c
@@ -20,7 +20,9 @@
  */
 
 #include "appearance.h"
-#include "stdio.h"
+#include "appearance-ui.h"
+
+#include <stdio.h>
 
 static void
 set_have_icons (AppearanceData *data, gboolean value)

--- a/capplets/appearance/mate-wp-xml.c
+++ b/capplets/appearance/mate-wp-xml.c
@@ -19,6 +19,7 @@
  */
 
 #include "appearance.h"
+#include "mate-wp-xml.h"
 #include "mate-wp-item.h"
 #include <gio/gio.h>
 #include <string.h>


### PR DESCRIPTION
Fix the warnings below:
```
appearance-ui.c:74:1: warning: no previous prototype for ‘ui_init’ [-Wmissing-prototypes]
appearance-style.c:987:1: warning: no previous prototype for ‘style_init’ [-Wmissing-prototypes]
appearance-style.c:1055:1: warning: no previous prototype for ‘style_shutdown’ [-Wmissing-prototypes]
appearance-font.c:732:6: warning: no previous prototype for ‘font_init’ [-Wmissing-prototypes]
appearance-font.c:799:6: warning: no previous prototype for ‘font_shutdown’ [-Wmissing-prototypes]
appearance-themes.c:976:6: warning: no previous prototype for ‘themes_init’ [-Wmissing-prototypes]
appearance-themes.c:1136:1: warning: no previous prototype for ‘themes_shutdown’ [-Wmissing-prototypes]
appearance-desktop.c:609:1: warning: no previous prototype for ‘wp_create_filechooser’ [-Wmissing-prototypes]
appearance-desktop.c:1212:1: warning: no previous prototype for ‘desktop_init’ [-Wmissing-prototypes]
appearance-desktop.c:1366:1: warning: no previous prototype for ‘desktop_shutdown’ [-Wmissing-prototypes]
appearance-support.c:117:1: warning: no previous prototype for ‘support_init’ [-Wmissing-prototypes]
appearance-support.c:132:1: warning: no previous prototype for ‘support_shutdown’ [-Wmissing-prototypes]
mate-wp-xml.c:420:6: warning: no previous prototype for ‘mate_wp_xml_load_list’ [-Wmissing-prototypes]
mate-wp-xml.c:473:6: warning: no previous prototype for ‘mate_wp_xml_save_list’ [-Wmissing-prototypes]
```