### PR TITLE
libwindow-settings: no previous prototype for ‘window_manager_new’

### DIFF
--- a/libwindow-settings/marco-window-manager.h
+++ b/libwindow-settings/marco-window-manager.h
@@ -25,5 +25,6 @@ struct _MarcoWindowManagerClass
 };
 
 GType      marco_window_manager_get_type             (void);
+GObject*   window_manager_new                        (int expected_interface_version);
 
 #endif


### PR DESCRIPTION
Fix the warning below:
```
marco-window-manager.c:87:1: warning: no previous prototype for ‘window_manager_new’ [-Wmissing-prototypes]
```