### PR TITLE
display: remove conversion warnings

### DIFF
--- a/capplets/display/mate-display-properties-install-systemwide.c
+++ b/capplets/display/mate-display-properties-install-systemwide.c
@@ -75,8 +75,8 @@ static gboolean
 copy_file (int source_fd, int dest_fd)
 {
 	char buf[1024];
-	int num_read;
-	int num_written;
+	ssize_t num_read;
+	ssize_t num_written;
 
 	while (TRUE) {
 		char *p;
@@ -94,7 +94,7 @@ copy_file (int source_fd, int dest_fd)
 
 		p = buf;
 		while (num_read > 0) {
-			num_written = write (dest_fd, p, num_read);
+			num_written = write (dest_fd, p, (size_t) num_read);
 			if (num_written == -1) {
 				if (errno == EINTR)
 					continue;
@@ -133,7 +133,7 @@ main (int argc, char **argv)
 	const char *source_filename;
 	const char *dest_name;
 	const char *pkexec_uid_str;
-	int pkexec_uid;
+	unsigned int pkexec_uid;
 	struct stat statbuf;
 	int err;
 	int source_fd;

--- a/capplets/display/scrollarea.c
+++ b/capplets/display/scrollarea.c
@@ -54,14 +54,14 @@ struct InputRegion
 
 struct AutoScrollInfo
 {
-    int				dx;
-    int				dy;
-    int				timeout_id;
-    int				begin_x;
-    int				begin_y;
-    double			res_x;
-    double			res_y;
-    GTimer		       *timer;
+    int                         dx;
+    int                         dy;
+    guint                       timeout_id;
+    int                         begin_x;
+    int                         begin_y;
+    double                      res_x;
+    double                      res_y;
+    GTimer                     *timer;
 };
 
 struct FooScrollAreaPrivate
@@ -403,7 +403,7 @@ static void
 clear_exposed_input_region (FooScrollArea *area,
 			    cairo_region_t *exposed)	/* in canvas coordinates */
 {
-    int i;
+    guint i;
     cairo_region_t *viewport;
     GdkRectangle allocation;
 
@@ -788,7 +788,7 @@ process_event (FooScrollArea	       *scroll_area,
 	       int			y)
 {
     GtkWidget *widget = GTK_WIDGET (scroll_area);
-    int i;
+    guint i;
 
     allocation_to_canvas (scroll_area, &x, &y);
 
@@ -874,7 +874,7 @@ foo_scroll_area_button_press (GtkWidget *widget,
 {
     FooScrollArea *area = FOO_SCROLL_AREA (widget);
 
-    process_gdk_event (area, event->x, event->y, (GdkEvent *)event);
+    process_gdk_event (area, (int) event->x, (int) event->y, (GdkEvent *)event);
 
     return TRUE;
 }
@@ -885,7 +885,7 @@ foo_scroll_area_button_release (GtkWidget *widget,
 {
     FooScrollArea *area = FOO_SCROLL_AREA (widget);
 
-    process_gdk_event (area, event->x, event->y, (GdkEvent *)event);
+    process_gdk_event (area, (int) event->x, (int) event->y, (GdkEvent *)event);
 
     return FALSE;
 }
@@ -896,7 +896,7 @@ foo_scroll_area_motion (GtkWidget *widget,
 {
     FooScrollArea *area = FOO_SCROLL_AREA (widget);
 
-    process_gdk_event (area, event->x, event->y, (GdkEvent *)event);
+    process_gdk_event (area, (int) event->x, (int) event->y, (GdkEvent *)event);
     return TRUE;
 }
 
@@ -1042,21 +1042,22 @@ foo_scrollbar_adjustment_changed (GtkAdjustment *adj,
     gint dx = 0;
     gint dy = 0;
     GdkRectangle old_viewport, new_viewport;
+    gdouble aux;
+    int offset;
 
     get_viewport (scroll_area, &old_viewport);
 
+    aux = gtk_adjustment_get_value (adj);
+    offset = (int) aux;
     if (adj == scroll_area->priv->hadj)
     {
-	/* FIXME: do we treat the offset as int or double, and,
-	 * if int, how do we round?
-	 */
-	dx = (int)gtk_adjustment_get_value (adj) - scroll_area->priv->x_offset;
-	scroll_area->priv->x_offset = gtk_adjustment_get_value (adj);
+	dx = offset - scroll_area->priv->x_offset;
+	scroll_area->priv->x_offset = offset;
     }
     else if (adj == scroll_area->priv->vadj)
     {
-	dy = (int)gtk_adjustment_get_value (adj) - scroll_area->priv->y_offset;
-	scroll_area->priv->y_offset = gtk_adjustment_get_value (adj);
+	dy = offset - scroll_area->priv->y_offset;
+	scroll_area->priv->y_offset = offset;
     }
     else
     {
@@ -1375,8 +1376,8 @@ scroll_idle (gpointer data)
     info->res_x = elapsed * info->dx / 0.2;
     info->res_y = elapsed * info->dy / 0.2;
 
-    new_x = viewport.x + info->res_x;
-    new_y = viewport.y + info->res_y;
+    new_x = viewport.x + (int) info->res_x;
+    new_y = viewport.y + (int) info->res_y;
 
     foo_scroll_area_set_viewport_pos (area, new_x, new_y);
 


### PR DESCRIPTION
```
xrandr-capplet.c:326:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
xrandr-capplet.c:379:10: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:380:11: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:571:6: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:572:6: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:611:10: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:612:11: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:933:21: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:934:21: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:971:40: warning: comparison of integer expressions of different signedness: ‘guint’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
xrandr-capplet.c:972:44: warning: comparison of integer expressions of different signedness: ‘guint’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
xrandr-capplet.c:1091:13: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:1111:18: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
xrandr-capplet.c:1262:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
xrandr-capplet.c:1270:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
xrandr-capplet.c:1319:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
xrandr-capplet.c:1327:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
xrandr-capplet.c:1548:14: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
xrandr-capplet.c:1549:14: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
xrandr-capplet.c:1564:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
xrandr-capplet.c:1699:68: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
scrollarea.c:417:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
scrollarea.c:426:65: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
scrollarea.c:803:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘guint’ {aka ‘unsigned int’} [-Wsign-compare]
scrollarea.c:877:35: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:877:45: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:888:35: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:888:45: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:899:35: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:899:45: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:1054:32: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:1059:32: warning: conversion from ‘gdouble’ {aka ‘double’} to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:1354:47: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
scrollarea.c:1378:13: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:1379:13: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
scrollarea.c:1410:6: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
mate-display-properties-install-systemwide.c:84:14: warning: conversion from ‘ssize_t’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
mate-display-properties-install-systemwide.c:97:37: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
mate-display-properties-install-systemwide.c:97:18: warning: conversion from ‘ssize_t’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
mate-display-properties-install-systemwide.c:217:21: warning: comparison of integer expressions of different signedness: ‘__uid_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
```