### PR TITLE
time-admin: g_time_zone_new is deprecated from glib 2.68

### DIFF
--- a/capplets/time-admin/src/time-zone.c
+++ b/capplets/time-admin/src/time-zone.c
@@ -296,7 +296,16 @@ update_timezone (TimezoneMap *map)
     current_location = timezone_map_get_location (TIMEZONEMAP (map));
     city_country = translated_city_name (current_location);
 
+#if GLIB_CHECK_VERSION (2, 68, 0)
+    if ((timezone =  g_time_zone_new_identifier (current_location->zone)) == NULL) {
+        timezone_map_set_bubble_text (TIMEZONEMAP (map),
+                                      _("Error: timezone identifier cannot be parsed or loaded"));
+        return;
+    }
+#else
     timezone = g_time_zone_new (current_location->zone);
+#endif
+
     current_date = g_date_time_new_now_local ();
     date = g_date_time_to_timezone (current_date, timezone);
 


### PR DESCRIPTION
Fedora 34 beta bundles glib2 2.68.0:
```
$ cat /etc/redhat-release 
Fedora release 34 (Thirty Four)
$ rpm -q --qf "%{VERSION}\n" glib2
2.68.0
```
Compiler warning:
```
time-zone.c: In function ‘update_timezone’:
time-zone.c:299:5: warning: ‘g_time_zone_new’ is deprecated: Use 'g_time_zone_new_identifier' instead [-Wdeprecated-declarations]
  299 |     timezone = g_time_zone_new (current_location->zone);
      |     ^~~~~~~~
```
https://developer.gnome.org/glib/stable/glib-GTimeZone.html#g-time-zone-new