### PR TITLE
windows-applet: group alt-tab options, remove reduced-resources option

### DIFF
--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -50,7 +50,6 @@
 #define MARCO_FOCUS_KEY "focus-mode"
 #define MARCO_AUTORAISE_KEY "auto-raise"
 #define MARCO_AUTORAISE_DELAY_KEY "auto-raise-delay"
-#define MARCO_REDUCED_RESOURCES_KEY "reduced-resources"
 #define MARCO_MOUSE_MODIFIER_KEY "mouse-button-modifier"
 
 #define MARCO_COMPOSITING_MANAGER_KEY "compositing-manager"
@@ -91,13 +90,13 @@ static GtkWidget *dialog_win;
 
 /* Behaviour */
 static GtkWidget *show_tab_border_checkbutton;
+static GtkWidget *compositing_fast_alt_tab_checkbutton;
 static GtkWidget *double_click_titlebar_optionmenu;
 static GtkWidget *focus_mode_checkbutton;
 static GtkWidget *focus_mode_mouse_checkbutton;
 static GtkWidget *autoraise_checkbutton;
 static GtkWidget *autoraise_delay_spinbutton;
 static GtkWidget *autoraise_delay_hbox;
-static GtkWidget *reduced_resources_checkbutton;
 static GtkWidget *alt_click_vbox;
 
 /* Placement */
@@ -108,7 +107,6 @@ static GtkWidget *titlebar_layout_optionmenu;
 
 /* Compositing Manager */
 static GtkWidget *compositing_checkbutton;
-static GtkWidget *compositing_fast_alt_tab_checkbutton;
 
 static GSettings *marco_settings;
 
@@ -124,11 +122,8 @@ update_sensitivity (void)
 
     gtk_widget_set_sensitive (compositing_fast_alt_tab_checkbutton,
                               g_settings_get_boolean (marco_settings, MARCO_COMPOSITING_MANAGER_KEY));
-    gtk_widget_set_sensitive (enable_tiling_checkbutton,
-                              !g_settings_get_boolean (marco_settings, MARCO_REDUCED_RESOURCES_KEY));
     gtk_widget_set_sensitive (allow_top_tiling_checkbutton,
-                              g_settings_get_boolean (marco_settings, MARCO_ALLOW_TILING_KEY) &&
-                             !g_settings_get_boolean (marco_settings, MARCO_REDUCED_RESOURCES_KEY));
+                              g_settings_get_boolean (marco_settings, MARCO_ALLOW_TILING_KEY));
     gtk_widget_set_sensitive (focus_mode_mouse_checkbutton,
                               g_settings_get_enum (marco_settings, MARCO_FOCUS_KEY) != FOCUS_MODE_CLICK);
     gtk_widget_set_sensitive (autoraise_delay_hbox,
@@ -362,13 +357,13 @@ main (int argc, char **argv)
 
     /* Behaviour */
     show_tab_border_checkbutton = GET_WIDGET ("show_tab_border_checkbutton");
+    compositing_fast_alt_tab_checkbutton = GET_WIDGET ("compositing_fast_alt_tab_checkbutton");
     double_click_titlebar_optionmenu = GET_WIDGET ("double_click_titlebar_optionmenu");
     focus_mode_checkbutton = GET_WIDGET ("focus_mode_checkbutton");
     focus_mode_mouse_checkbutton = GET_WIDGET ("focus_mode_mouse_checkbutton");
     autoraise_delay_hbox = GET_WIDGET ("autoraise_delay_hbox");
     autoraise_checkbutton = GET_WIDGET ("autoraise_checkbutton");
     autoraise_delay_spinbutton = GET_WIDGET ("autoraise_delay_spinbutton");
-    reduced_resources_checkbutton = GET_WIDGET ("reduced_resources_checkbutton");
     alt_click_vbox = GET_WIDGET ("alt_click_vbox");
 
     /* Placement */
@@ -377,9 +372,8 @@ main (int argc, char **argv)
     allow_top_tiling_checkbutton = GET_WIDGET ("allow_top_tiling_checkbutton");
     titlebar_layout_optionmenu = GET_WIDGET ("titlebar_layout_optionmenu");
 
-    /* Composition Manager */
+    /* Compositing Manager */
     compositing_checkbutton = GET_WIDGET ("compositing_checkbutton");
-    compositing_fast_alt_tab_checkbutton = GET_WIDGET ("compositing_fast_alt_tab_checkbutton");
 
     g_object_unref (builder);
 
@@ -411,10 +405,10 @@ main (int argc, char **argv)
                      G_SETTINGS_BIND_DEFAULT);
 
     g_settings_bind (marco_settings,
-                     MARCO_REDUCED_RESOURCES_KEY,
-                     reduced_resources_checkbutton,
+                     MARCO_COMPOSITING_FAST_ALT_TAB_KEY,
+                     compositing_fast_alt_tab_checkbutton,
                      "active",
-                     G_SETTINGS_BIND_DEFAULT);
+                     G_SETTINGS_BIND_DEFAULT | G_SETTINGS_BIND_INVERT_BOOLEAN);
 
     /* Placement */
     g_settings_bind (marco_settings,
@@ -435,16 +429,10 @@ main (int argc, char **argv)
                      "active",
                      G_SETTINGS_BIND_DEFAULT);
 
-    /* Composition Manager */
+    /* Compositing Manager */
     g_settings_bind (marco_settings,
                      MARCO_COMPOSITING_MANAGER_KEY,
                      compositing_checkbutton,
-                     "active",
-                     G_SETTINGS_BIND_DEFAULT);
-
-    g_settings_bind (marco_settings,
-                     MARCO_COMPOSITING_FAST_ALT_TAB_KEY,
-                     compositing_fast_alt_tab_checkbutton,
                      "active",
                      G_SETTINGS_BIND_DEFAULT);
 

--- a/capplets/windows/window-properties.ui
+++ b/capplets/windows/window-properties.ui
@@ -361,12 +361,26 @@ Author: Robert Buj
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="position_and_behavior_vbox3">
+                      <object class="GtkBox" id="alt_tab_vbox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkCheckButton" id="compositing_fast_alt_tab_checkbutton">
+                            <property name="label" translatable="yes">Show _thumbnails in Alt-Tab</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
                         <child>
                           <object class="GtkCheckButton" id="show_tab_border_checkbutton">
                             <property name="label" translatable="yes">Show window _border in Alt-Tab</property>
@@ -379,14 +393,14 @@ Author: Robert Buj
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">0</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">2</property>
+                        <property name="position">3</property>
                       </packing>
                     </child>
                   </object>
@@ -394,64 +408,6 @@ Author: Robert Buj
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="performance_main_vbox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel" id="performance_label">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Performance</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="performance_vbox">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-start">6</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkCheckButton" id="reduced_resources_checkbutton">
-                            <property name="label" translatable="yes">Use _reduced resources</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -827,22 +783,6 @@ Author: Robert Buj
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="compositing_fast_alt_tab_checkbutton">
-                            <property name="label" translatable="yes">Disable _thumbnails in Alt-Tab</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="margin-start">12</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
in a way it makes more sense. The alt-tab options are now grouped together. The "Compositing Manager" tab is now the "Performance" tab, which is better because there can be added more options in the future such as "disable animations".

![Screenshot at 2021-03-28 11-23-49](https://user-images.githubusercontent.com/39454100/112747843-3a4fe100-8fb8-11eb-88b6-21a74603b68d.png)
![Screenshot at 2021-03-28 11-24-17](https://user-images.githubusercontent.com/39454100/112747845-3ae87780-8fb8-11eb-897a-0d210115f0b0.png)
![Screenshot at 2021-03-28 11-24-34](https://user-images.githubusercontent.com/39454100/112747846-3b810e00-8fb8-11eb-98be-0bc87e9c142d.png)
