### PR TITLE
windows-applet: add custom titlebar button layout option

### DIFF
--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -40,6 +40,9 @@
 #include "capplet-util.h"
 
 #define MARCO_SCHEMA "org.mate.Marco.general"
+#define INTERFACE_SCHEMA "org.mate.interface"
+
+#define GTK_BUTTON_LAYOUT_KEY "gtk-decoration-layout"
 
 #define MARCO_CENTER_NEW_WINDOWS_KEY "center-new-windows"
 #define MARCO_ALLOW_TILING_KEY "allow-tiling"
@@ -124,6 +127,7 @@ static GtkWidget *compositing_checkbutton;
 static GtkWidget *compositing_fast_alt_tab_checkbutton;
 
 static GSettings *marco_settings;
+static GSettings *interface_settings;
 
 static MouseClickModifier *mouse_modifiers = NULL;
 static int n_mouse_modifiers = 0;
@@ -421,6 +425,7 @@ main (int argc, char **argv)
 
     /* Load settings */
     marco_settings = g_settings_new (MARCO_SCHEMA);
+    interface_settings = g_settings_new (INTERFACE_SCHEMA);
 
     reload_mouse_modifiers ();
 
@@ -516,6 +521,7 @@ main (int argc, char **argv)
     gtk_main ();
 
     g_object_unref (marco_settings);
+    g_object_unref (interface_settings);
 
     g_free (custom_titlebar_button_layout);
 

--- a/capplets/windows/mate-window-properties.c
+++ b/capplets/windows/mate-window-properties.c
@@ -56,8 +56,21 @@
 #define MARCO_COMPOSITING_MANAGER_KEY "compositing-manager"
 #define MARCO_COMPOSITING_FAST_ALT_TAB_KEY "compositing-fast-alt-tab"
 
-#define MARCO_BUTTON_LAYOUT_RIGHT "menu:minimize,maximize,close"
-#define MARCO_BUTTON_LAYOUT_LEFT "close,minimize,maximize:"
+enum
+{
+    MARCO_BUTTON_LAYOUT_RIGHT_WITH_MENU = 0,
+    MARCO_BUTTON_LAYOUT_LEFT_WITH_MENU,
+    MARCO_BUTTON_LAYOUT_RIGHT,
+    MARCO_BUTTON_LAYOUT_LEFT,
+    MARCO_BUTTON_LAYOUT_COUNT
+};
+
+static const char *button_layout [MARCO_BUTTON_LAYOUT_COUNT] = {
+   [MARCO_BUTTON_LAYOUT_RIGHT_WITH_MENU] = "menu:minimize,maximize,close",
+   [MARCO_BUTTON_LAYOUT_LEFT_WITH_MENU]  = "close,minimize,maximize:menu",
+   [MARCO_BUTTON_LAYOUT_RIGHT]           = ":minimize,maximize,close",
+   [MARCO_BUTTON_LAYOUT_LEFT]            = "close,minimize,maximize:"
+};
 
 /* keep following enums in sync with marco */
 enum
@@ -120,8 +133,6 @@ static void reload_mouse_modifiers (void);
 static void
 update_sensitivity (void)
 {
-    gchar *str;
-
     gtk_widget_set_sensitive (compositing_fast_alt_tab_checkbutton,
                               g_settings_get_boolean (marco_settings, MARCO_COMPOSITING_MANAGER_KEY));
     gtk_widget_set_sensitive (enable_tiling_checkbutton,
@@ -136,12 +147,6 @@ update_sensitivity (void)
     gtk_widget_set_sensitive (autoraise_delay_spinbutton,
                               g_settings_get_enum (marco_settings, MARCO_FOCUS_KEY) != FOCUS_MODE_CLICK &&
                               g_settings_get_boolean (marco_settings, MARCO_AUTORAISE_KEY));
-
-    str = g_settings_get_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY);
-    gtk_widget_set_sensitive (titlebar_layout_optionmenu,
-                              g_strcmp0 (str, MARCO_BUTTON_LAYOUT_LEFT) == 0 ||
-                              g_strcmp0 (str, MARCO_BUTTON_LAYOUT_RIGHT) == 0);
-    g_free (str);
 }
 
 static void
@@ -203,18 +208,48 @@ double_click_titlebar_changed_callback (GtkWidget *optionmenu,
                          gtk_combo_box_get_active (GTK_COMBO_BOX (optionmenu)));
 }
 
+static gchar *custom_titlebar_button_layout = NULL;
+
 static void
-titlebar_layout_changed_callback (GtkWidget *optionmenu,
-                                  void      *data)
+titlebar_layout_changed_callback (GtkWidget *optionmenu)
 {
     gint value = gtk_combo_box_get_active (GTK_COMBO_BOX (optionmenu));
 
-    if (value == 0) {
-        g_settings_set_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY, MARCO_BUTTON_LAYOUT_RIGHT);
+    if (value < MARCO_BUTTON_LAYOUT_COUNT) {
+        g_settings_set_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY, button_layout[value]);
+        g_settings_set_string (interface_settings, GTK_BUTTON_LAYOUT_KEY, button_layout[value]);
     }
-    else if (value == 1) {
-        g_settings_set_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY, MARCO_BUTTON_LAYOUT_LEFT);
+    /* Custom Layout */
+    else if ((value == MARCO_BUTTON_LAYOUT_COUNT) && custom_titlebar_button_layout) {
+        g_settings_set_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY, custom_titlebar_button_layout);
+        g_settings_set_string (interface_settings, GTK_BUTTON_LAYOUT_KEY, custom_titlebar_button_layout);
     }
+}
+
+static void
+set_titlebar_button_layout(void)
+{
+    gchar    *str;
+    gboolean  found = FALSE;
+
+    str = g_settings_get_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY);
+    for (gint i = 0; i < MARCO_BUTTON_LAYOUT_COUNT; i++) {
+        if (g_strcmp0 (str, button_layout[i]) == 0) {
+            gtk_combo_box_set_active (GTK_COMBO_BOX (titlebar_layout_optionmenu), i);
+            found = TRUE;
+            break;
+        }
+    }
+    /* A custom value is found in MARCO_BUTTON_LAYOUT_KEY
+     * (maybe the user changed the value in dconf-editor) */
+    if (!found) {
+        g_free (custom_titlebar_button_layout);
+        custom_titlebar_button_layout = g_strdup(str);
+        gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (titlebar_layout_optionmenu), _("Custom"));
+        gtk_combo_box_set_active (GTK_COMBO_BOX (titlebar_layout_optionmenu), 4);
+    }
+
+    g_free(str);
 }
 
 static void
@@ -315,7 +350,6 @@ main (int argc, char **argv)
     GtkBuilder *builder;
     GdkScreen  *screen;
     GtkWidget  *nb;
-    gchar      *str;
     const char *current_wm;
     int i;
 
@@ -390,13 +424,10 @@ main (int argc, char **argv)
 
     reload_mouse_modifiers ();
 
-    str = g_settings_get_string (marco_settings, MARCO_BUTTON_LAYOUT_KEY);
-    gtk_combo_box_set_active (GTK_COMBO_BOX (titlebar_layout_optionmenu),
-                              g_strcmp0 (str, MARCO_BUTTON_LAYOUT_RIGHT) == 0 ? 0 : 1);
-    g_free (str);
-
     gtk_combo_box_set_active (GTK_COMBO_BOX (double_click_titlebar_optionmenu),
                               g_settings_get_enum (marco_settings, MARCO_DOUBLE_CLICK_TITLEBAR_KEY));
+
+    set_titlebar_button_layout ();
 
     set_alt_click_value ();
 
@@ -485,6 +516,8 @@ main (int argc, char **argv)
     gtk_main ();
 
     g_object_unref (marco_settings);
+
+    g_free (custom_titlebar_button_layout);
 
     return 0;
 }

--- a/capplets/windows/window-properties.ui
+++ b/capplets/windows/window-properties.ui
@@ -715,6 +715,7 @@ Author: Robert Buj
                               <object class="GtkLabel" id="position_of_titlebar_buttons_label">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="halign">start</property>
                                 <property name="label" translatable="yes">_Position of titlebar buttons:</property>
                                 <property name="use-underline">True</property>
                                 <property name="mnemonic-widget">titlebar_layout_optionmenu</property>
@@ -730,6 +731,8 @@ Author: Robert Buj
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <items>
+                                  <item translatable="yes">Right (with menu)</item>
+                                  <item translatable="yes">Left (with menu)</item>
                                   <item translatable="yes">Right</item>
                                   <item translatable="yes">Left</item>
                                 </items>
@@ -751,14 +754,14 @@ Author: Robert Buj
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">True</property>
+                    <property name="fill">False</property>
                     <property name="position">2</property>
                   </packing>
                 </child>

--- a/capplets/windows/window-properties.ui
+++ b/capplets/windows/window-properties.ui
@@ -715,7 +715,6 @@ Author: Robert Buj
                               <object class="GtkLabel" id="position_of_titlebar_buttons_label">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="halign">start</property>
                                 <property name="label" translatable="yes">_Position of titlebar buttons:</property>
                                 <property name="use-underline">True</property>
                                 <property name="mnemonic-widget">titlebar_layout_optionmenu</property>
@@ -754,14 +753,14 @@ Author: Robert Buj
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>


### PR DESCRIPTION
Fixes #640 
**Updated:**
The possible values for titlebar buttons positions are now: Right (with menu), Left (with menu), Right, Left.
With this PR, if the user altered the value via dconf-editor or mate-tweak or in another way to a different value, mcc does not overwrite this setting.

Test:
change marco->general->button-layout in dconf to an arbitrary value.
With PR the gsettings value is respected (not overwritten) when opening the windows applet from mcc.

**Update 2:**
csd windows respect the titlebar button layout as well, (see https://github.com/mate-desktop/mate-control-center/pull/574)
