### PR TITLE
Use gtk-cancel icon replace window-close icon

### DIFF
--- a/capplets/display/display-capplet.ui
+++ b/capplets/display/display-capplet.ui
@@ -35,7 +35,7 @@
   <object class="GtkImage" id="window_close_button_img">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="icon-name">window-close</property>
+    <property name="icon-name">gtk-cancel</property>
   </object>
   <object class="GtkDialog" id="dialog">
     <property name="can-focus">False</property>


### PR DESCRIPTION
Use gtk-cancel icon replace window-close icon，Icons belong to the same category, which is more beautiful and harmonious
![2021-07-11 02-16-09 创建的截图](https://user-images.githubusercontent.com/36913152/125159642-42204380-e1ab-11eb-8b39-6d4ed304bb2a.png)
Fix #648 