### PR TITLE
Fix compilation warning

### DIFF
--- a/capplets/about-me/mate-about-me-password.c
+++ b/capplets/about-me/mate-about-me-password.c
@@ -42,6 +42,7 @@
 #endif
 
 #include "capplet-util.h"
+#include "mate-about-me-password.h"
 
 /* Passwd states */
 typedef enum {
@@ -90,7 +91,7 @@ typedef struct {
  */
 #define PASSDLG_ERROR (mate_about_me_password_error_quark())
 
-GQuark mate_about_me_password_error_quark(void)
+static GQuark mate_about_me_password_error_quark(void)
 {
 	static GQuark q = 0;
 

--- a/capplets/keyboard/mate-keyboard-properties-xkb.c
+++ b/capplets/keyboard/mate-keyboard-properties-xkb.c
@@ -253,7 +253,7 @@ enable_disable_restoring (GtkBuilder * dialog)
 	gtk_widget_set_sensitive (WID ("xkb_reset_to_defaults"), enable);
 }
 
-void
+static void
 xkb_save_gslist_as_strv (gchar *schema, gchar *key, GSList *list)
 {
 	GSettings *settings;

--- a/capplets/keyboard/mate-keyboard-properties-xkbltadd.c
+++ b/capplets/keyboard/mate-keyboard-properties-xkbltadd.c
@@ -366,20 +366,7 @@ xkb_layout_chooser_available_layouts_fill (GtkBuilder *
 				  chooser_dialog);
 }
 
-GSList*
-xkb_layout_gslist_from_strv (gchar **array)
-{
-    GSList *list = NULL;
-    gint i;
-    if (array != NULL) {
-        for (i = 0; array[i]; i++) {
-            list = g_slist_append (list, g_strdup (array[i]));
-        }
-    }
-    return list;
-}
-
-gchar **
+static gchar **
 xkb_layout_strv_from_gslist (GSList *list)
 {
     GArray *array;
@@ -393,7 +380,7 @@ xkb_layout_strv_from_gslist (GSList *list)
 
 
 
-void
+static void
 xkl_layout_chooser_add_default_switcher_if_necessary (GSList *
 						      layouts_list)
 {

--- a/font-viewer/font-view.c
+++ b/font-viewer/font-view.c
@@ -45,6 +45,7 @@
 #define FONT_VIEW_APPLICATION(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST ((obj), FONT_VIEW_TYPE_APPLICATION, FontViewApplication))
 
+static GType font_view_application_get_type (void);
 typedef struct {
     GtkApplication parent;
 


### PR DESCRIPTION
Fixed some compilation warnings that there were ``` no previous prototypes [- wmissing prototypes]```
We still have a lot to do. There are too many outdated APIs that we need to replace