### PR TITLE
Replace the deprecated GtkTable with GtkGrid

### DIFF
--- a/libslab/app-resizer.h
+++ b/libslab/app-resizer.h
@@ -50,6 +50,8 @@ struct _AppResizer
 	gboolean table_elements_homogeneous;
 	gint cur_num_cols;
 	gboolean setting_style;
+
+	guint column;
 	AppShellData *app_data;
 };
 
@@ -64,7 +66,7 @@ GType app_resizer_get_type (void);
 GtkWidget *app_resizer_new (GtkBox * child, gint initial_num_columns, gboolean homogeneous,
 	AppShellData * app_data);
 void app_resizer_set_table_cache (AppResizer * widget, GList * cache_list);
-void app_resizer_layout_table_default (AppResizer * widget, GtkTable * table, GList * element_list);
+void app_resizer_layout_table_default (AppResizer * widget, GtkGrid * table, GList * element_list);
 void app_resizer_set_vadjustment_value (GtkWidget * widget, gdouble value);
 
 G_END_DECLS

--- a/libslab/app-shell.c
+++ b/libslab/app-shell.c
@@ -723,9 +723,9 @@ create_application_category_sections (AppShellData * app_data)
 		g_free (markup);
 
 		hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-		table = gtk_table_new (0, 0, TRUE);
-		gtk_table_set_col_spacings (GTK_TABLE (table), 5);
-		gtk_table_set_row_spacings (GTK_TABLE (table), 5);
+		table = gtk_grid_new ();
+		gtk_grid_set_column_spacing (GTK_GRID (table), 5);
+		gtk_grid_set_row_spacing (GTK_GRID (table), 5);
 		gtk_box_pack_start (GTK_BOX (hbox), table, FALSE, FALSE, 15);
 		slab_section_set_contents (SLAB_SECTION (data->section), hbox);
 	}
@@ -804,7 +804,7 @@ populate_application_category_section (AppShellData * app_data, SlabSection * se
 	GList * launcher_list)
 {
 	GtkWidget *hbox;
-	GtkTable *table;
+	GtkGrid *table;
 	GList *children;
 
 	hbox = GTK_WIDGET (section->contents);
@@ -813,8 +813,8 @@ populate_application_category_section (AppShellData * app_data, SlabSection * se
 	table = children->data;
 	g_list_free (children);
 
-	/* Make sure our implementation has not changed and it's still a GtkTable */
-	g_assert (GTK_IS_TABLE (table));
+	/* Make sure our implementation has not changed and it's still a GtkGrid */
+	g_assert (GTK_IS_GRID (table));
 
 	app_data->cached_tables_list = g_list_append (app_data->cached_tables_list, table);
 


### PR DESCRIPTION
Reduce compilation warnings 
Replace the deprecated GtkTable with GtkGrid
The display effect is the same as before, and there is no warning at runtime