### PR TITLE
Maintain compatibility with GLib versions older than 2.66. Fixes #655

### DIFF
--- a/libslab/bookmark-agent.c
+++ b/libslab/bookmark-agent.c
@@ -168,7 +168,11 @@ bookmark_agent_add_item (BookmarkAgent *this, const BookmarkItem *item)
 	g_bookmark_file_set_mime_type (priv->store, item->uri, item->mime_type);
 
 	if (item->mtime)
+		#if GLIB_CHECK_VERSION(2,66,0)
 		g_bookmark_file_set_modified_date_time (priv->store, item->uri, item->mtime);
+		#else
+		g_bookmark_file_set_modified (priv->store, item->uri, item->mtime);
+		#endif
 
 	if (item->title)
 		g_bookmark_file_set_title (priv->store, item->uri, item->title);
@@ -321,7 +325,11 @@ make_items_from_bookmark_file (BookmarkAgent *this, GBookmarkFile *store)
 
 			item->uri       = g_strdup (uris [i]);
 			item->mime_type = g_bookmark_file_get_mime_type (store, uris [i], NULL);
+			#if GLIB_CHECK_VERSION(2,66,0)
 			item->mtime     = g_bookmark_file_get_modified_date_time  (store, uris [i], NULL);
+			#else
+			item->mtime     = g_bookmark_file_get_modified (store, uris [i], NULL);
+			#endif
 
 			items_ordered = g_list_prepend (items_ordered, item);
 		}
@@ -356,7 +364,11 @@ bookmark_agent_update_from_bookmark_file (BookmarkAgent *this, GBookmarkFile *st
 		item = (BookmarkItem *) node->data;
 
 		g_bookmark_file_set_mime_type (priv->store, item->uri, item->mime_type);
+		#if GLIB_CHECK_VERSION(2,66,0)
 		g_bookmark_file_set_modified_date_time  (priv->store, item->uri, item->mtime);
+		#else
+		g_bookmark_file_set_modified (priv->store, item->uri, item->mtime);
+		#endif
 
 		bookmark_item_free (item);
 	}
@@ -718,7 +730,11 @@ update_items (BookmarkAgent *this)
 			priv->items [i]->uri       = g_strdup (uris_ordered [i]);
 			priv->items [i]->title     = g_bookmark_file_get_title     (priv->store, uris_ordered [i], NULL);
 			priv->items [i]->mime_type = g_bookmark_file_get_mime_type (priv->store, uris_ordered [i], NULL);
+			#if GLIB_CHECK_VERSION(2,66,0)
 			priv->items [i]->mtime     = g_bookmark_file_get_modified_date_time (priv->store, uris_ordered [i], NULL);
+			#else
+			priv->items [i]->mtime     = g_bookmark_file_get_modified (priv->store, uris_ordered [i], NULL);
+			#endif
 			priv->items [i]->app_name  = NULL;
 			priv->items [i]->app_exec  = NULL;
 


### PR DESCRIPTION
g_bookmark_file_set_modified_date_time is used in libslab/bookmark-agent.c which sets the last time the bookmark for uri was last modified.

g_bookmark_file_set_modified_date_time is only available in GLib 2.66 and newer.
