### PR TITLE
Include audio mixers in hardware category

### DIFF
--- a/shell/matecc.menu
+++ b/shell/matecc.menu
@@ -76,6 +76,11 @@
         <Category>HardwareSettings</Category>
         <Not><Category>System</Category></Not>
       </And>
+      <And>
+        <Category>AudioVideo</Category>
+        <Category>Mixer</Category>
+        <Not><Category>System</Category></Not>
+      </And>
     </Include>
   </Menu> <!-- End Hardware -->
 


### PR DESCRIPTION
Rule: AudioVideo AND Mixer AND (NOT System)
- [AudioVideo](https://specifications.freedesktop.org/menu-spec/latest/apa.html): Main Category
- [Mixer](https://specifications.freedesktop.org/menu-spec/latest/apas02.html): Additional Categories
- [System](https://specifications.freedesktop.org/menu-spec/latest/apa.html): Main Category
