### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -160,7 +160,7 @@ main (int argc, char **argv)
       	&wallpaper_files,
       	NULL,
       	N_("[WALLPAPER...]") },
-      { NULL }
+      { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
 
   option_context = g_option_context_new (NULL);

--- a/capplets/default-applications/mate-da-capplet.c
+++ b/capplets/default-applications/mate-da-capplet.c
@@ -782,7 +782,9 @@ main(int argc, char** argv)
 			N_("Specify the name of the page to show (internet|multimedia|system|a11y)"),
 			N_("page")
 		},
-		{NULL}
+		{
+			NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL
+		}
 	};
 
 	GOptionContext* context = g_option_context_new(_("- MATE Default Applications"));

--- a/capplets/keybindings/eggcellrendererkeys.c
+++ b/capplets/keybindings/eggcellrendererkeys.c
@@ -66,7 +66,8 @@ GType egg_cell_renderer_keys_get_type(void)
 			NULL,		/* class_data */
 			sizeof (EggCellRendererKeys),
 			0,              /* n_preallocs */
-			(GInstanceInitFunc) egg_cell_renderer_keys_init
+			(GInstanceInitFunc) egg_cell_renderer_keys_init,
+			NULL
 		};
 
 	  cell_keys_type = g_type_register_static (GTK_TYPE_CELL_RENDERER_TEXT, "EggCellRendererKeys", &cell_keys_info, 0);
@@ -522,6 +523,7 @@ pointless_eventbox_subclass_get_type (void)
         sizeof (GtkEventBox),
 	0,              /* n_preallocs */
         (GInstanceInitFunc) NULL,
+        NULL
       };
 
       static const GInterfaceInfo cell_editable_info = {

--- a/capplets/keyboard/mate-keyboard-properties.c
+++ b/capplets/keyboard/mate-keyboard-properties.c
@@ -178,7 +178,7 @@ main (int argc, char **argv)
 		 N_
 		 ("Start the page with the accessibility settings showing"),
 		 NULL},
-		{NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 

--- a/capplets/mouse/mate-mouse-properties.c
+++ b/capplets/mouse/mate-mouse-properties.c
@@ -399,7 +399,7 @@ main (int argc, char **argv)
 		 /* TRANSLATORS: don't translate the terms in brackets */
 		 N_("Specify the name of the page to show (general)"),
 		 N_("page") },
-		{NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	context = g_option_context_new (_("- MATE Mouse Preferences"));

--- a/font-viewer/font-thumbnailer.c
+++ b/font-viewer/font-thumbnailer.c
@@ -196,7 +196,7 @@ main (int argc,
 	      N_("Thumbnail size (default: 128)"), N_("SIZE") },
 	    { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &arguments,
 	      NULL, N_("FONT-FILE OUTPUT-FILE") },
-	    { NULL }
+	    { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
 
 #ifdef ENABLE_NLS

--- a/font-viewer/font-view.c
+++ b/font-viewer/font-view.c
@@ -791,8 +791,8 @@ action_about (GSimpleAction *action,
 }
 
 static GActionEntry action_entries[] = {
-    { "about", action_about, NULL, NULL, NULL },
-    { "quit", action_quit, NULL, NULL, NULL }
+    { "about", action_about, NULL, NULL, NULL, { 0 } },
+    { "quit", action_quit, NULL, NULL, NULL, { 0 } }
 };
 
 static void

--- a/shell/control-center.c
+++ b/shell/control-center.c
@@ -162,7 +162,7 @@ int main(int argc, char* argv[])
 	GError* error;
 	GOptionEntry options[] = {
 		{"hide", 0, 0, G_OPTION_ARG_NONE, &hidden, N_("Hide on start (useful to preload the shell)"), NULL},
-		{NULL}
+		{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
 	};
 
 #ifdef ENABLE_NLS

--- a/typing-break/drw-monitor.c
+++ b/typing-break/drw-monitor.c
@@ -75,6 +75,7 @@ drw_monitor_get_type (void)
 			sizeof (DrwMonitor),
 			0,              /* n_preallocs */
 			(GInstanceInitFunc) drw_monitor_init,
+			NULL
 		};
 
 		object_type = g_type_register_static (G_TYPE_OBJECT,

--- a/typing-break/main.c
+++ b/typing-break/main.c
@@ -62,7 +62,7 @@ main (int argc, char *argv[])
             N_("Enable debugging code"), NULL },
           { "no-check", 'n', 0, G_OPTION_ARG_NONE, &no_check,
             N_("Don't check whether the notification area exists"), NULL },
-	  { NULL }
+	  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
         };
         GOptionContext *option_context;
         GError *error = NULL;


### PR DESCRIPTION
```
appearance-main.c:163:14: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
      { NULL }
             ^
--
mate-da-capplet.c:785:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
mate-keyboard-properties.c:181:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
eggcellrendererkeys.c:70:3: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
                };
                ^
--
eggcellrendererkeys.c:525:7: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
      };
      ^
--
mate-mouse-properties.c:402:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
font-thumbnailer.c:199:13: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
            { NULL }
                   ^
--
font-view.c:794:47: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
    { "about", action_about, NULL, NULL, NULL },
                                              ^
font-view.c:795:45: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
    { "quit", action_quit, NULL, NULL, NULL }
                                            ^
--
control-center.c:165:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
main.c:65:11: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
          { NULL }
                 ^
--
drw-monitor.c:78:3: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
                };
                ^
```