### PR TITLE
appearance-style: fix memory leak

### DIFF
--- a/capplets/appearance/appearance-style.c
+++ b/capplets/appearance/appearance-style.c
@@ -253,6 +253,7 @@ static void update_message_area(AppearanceData* data)
 		gtk_box_pack_start (GTK_BOX (parent), data->style_message_area, FALSE, FALSE, 0);
 	}
 
+  g_free (engine);
   gtk_widget_hide(data->style_message_area);
 }
 


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fa87bee293f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fa87a7c0b7f in g_malloc ../glib/gmem.c:106
    #2 0x7fa87a7c0ec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fa87a7e31a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x43c306 in gtk_theme_info_missing_engine /home/robert/builddir.gcc/mate-control-center/capplets/common/mate-theme-info.c:1401
    #5 0x424548 in update_message_area /home/robert/builddir.gcc/mate-control-center/capplets/appearance/appearance-style.c:216
    #6 0x4290dd in style_init /home/robert/builddir.gcc/mate-control-center/capplets/appearance/appearance-style.c:1052
    #7 0x41be9b in main /home/robert/builddir.gcc/mate-control-center/capplets/appearance/appearance-main.c:176
    #8 0x7fa87a43eb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```