### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/capplets/common/mate-theme-info.c
+++ b/capplets/common/mate-theme-info.c
@@ -726,13 +726,13 @@ update_theme_index (GFile            *index_uri,
 
     if (key_element & MATE_THEME_GTK_2) {
       theme_used_to_exist = theme_info->has_gtk;
-      theme_info->has_gtk = theme_exists;
+      theme_info->has_gtk = (theme_exists != FALSE);
     } else if (key_element & MATE_THEME_GTK_2_KEYBINDING) {
       theme_used_to_exist = theme_info->has_keybinding;
-      theme_info->has_keybinding = theme_exists;
+      theme_info->has_keybinding = (theme_exists != FALSE);
     } else if (key_element & MATE_THEME_MARCO) {
       theme_used_to_exist = theme_info->has_marco;
-      theme_info->has_marco = theme_exists;
+      theme_info->has_marco = (theme_exists != FALSE);
     }
 
     if (!theme_info->has_marco && !theme_info->has_keybinding && !theme_info->has_gtk) {

--- a/libwindow-settings/marco-window-manager.c
+++ b/libwindow-settings/marco-window-manager.c
@@ -287,8 +287,8 @@ marco_get_settings (MateWindowManager *wm,
         }
 
         if (to_get & MATE_WM_SETTING_AUTORAISE) {
-                settings->autoraise = g_settings_get_boolean (meta_wm->p->settings,
-                                                              MARCO_AUTORAISE_KEY);
+                settings->autoraise = (g_settings_get_boolean (meta_wm->p->settings,
+                                                               MARCO_AUTORAISE_KEY) != FALSE);
                 settings->flags |= MATE_WM_SETTING_AUTORAISE;
         }
 


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
marco-window-manager.c:290:39: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                settings->autoraise = g_settings_get_boolean (meta_wm->p->settings,
                                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
mate-theme-info.c:729:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
      theme_info->has_gtk = theme_exists;
                          ~ ^~~~~~~~~~~~
mate-theme-info.c:732:36: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
      theme_info->has_keybinding = theme_exists;
                                 ~ ^~~~~~~~~~~~
mate-theme-info.c:735:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
      theme_info->has_marco = theme_exists;
                            ~ ^~~~~~~~~~~~
```