### PR TITLE
keyboard: fix memory leak

### DIFF
--- a/capplets/keyboard/mate-keyboard-properties-xkbmc.c
+++ b/capplets/keyboard/mate-keyboard-properties-xkbmc.c
@@ -43,27 +43,30 @@ static void fill_models_list (GtkBuilder * chooser_dialog);
 static gboolean fill_vendors_list (GtkBuilder * chooser_dialog);
 
 static GtkTreePath *
-gtk_list_store_find_entry (GtkListStore * list_store,
-			   GtkTreeIter * iter, gchar * name, int column_id)
+gtk_list_store_find_entry (GtkListStore   *list_store,
+                           GtkTreeIter    *iter,
+                           gchar          *name,
+                           int             column_id)
 {
-	GtkTreePath *path;
-	char *current_name = NULL;
-	if (gtk_tree_model_get_iter_first
-	    (GTK_TREE_MODEL (list_store), iter)) {
-		do {
-			gtk_tree_model_get (GTK_TREE_MODEL
-					    (list_store), iter, column_id,
-					    &current_name, -1);
-			if (!g_ascii_strcasecmp (name, current_name)) {
-				path =
-				    gtk_tree_model_get_path
-				    (GTK_TREE_MODEL (list_store), iter);
-				return path;
-			}
-			g_free (current_name);
-		} while (gtk_tree_model_iter_next
-			 (GTK_TREE_MODEL (list_store), iter));
-	}
+	GtkTreeModel *tree_model = GTK_TREE_MODEL (list_store);
+
+	if (!gtk_tree_model_get_iter_first (tree_model, iter))
+		return NULL;
+
+	do {
+		char *current_name;
+		gint  res;
+
+		gtk_tree_model_get (tree_model, iter,
+		                    column_id, &current_name,
+		                    -1);
+		res = g_ascii_strcasecmp (name, current_name);
+		g_free (current_name);
+		if (res == 0) {
+			return gtk_tree_model_get_path (tree_model, iter);
+		}
+	} while (gtk_tree_model_iter_next (tree_model, iter));
+
 	return NULL;
 }
 


### PR DESCRIPTION
```
CFLAGS="-ggdb3 -O0 -fsanitize=address" LDFLAGS="-fsanitize=address" ./autogen.sh --prefix=/usr && make && sudo make install
```
```
Direct leak of 1263 byte(s) in 133 object(s) allocated from:
    #0 0x7fdec0b3f93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fdebf2274df in g_malloc ../glib/gmem.c:106
    #2 0x7fdebf227822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fdebf249e35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x7fdebf369016 in value_lcopy_string ../gobject/gvaluetypes.c:313
    #5 0x7fdebff838fc in gtk_tree_model_get_valist ../gtk/gtktreemodel.c:1812
    #6 0x7fdebff8334b in gtk_tree_model_get ../gtk/gtktreemodel.c:1774
    #7 0x4099e0 in gtk_list_store_find_entry /home/robert/builddir.gcc/mate-control-center/capplets/keyboard/mate-keyboard-properties-xkbmc.c:54
    #8 0x409c39 in add_vendor_to_list /home/robert/builddir.gcc/mate-control-center/capplets/keyboard/mate-keyboard-properties-xkbmc.c:94
    #9 0x7fdebf1a3a59 in xkl_config_registry_foreach_in_nodeset.part.0 (/lib64/libxklavier.so.16+0xfa59)
```