### PR TITLE
Adding accelerators for the Apply/Close buttons in "Monitor Preferences". Useful for 4k monitors

### DIFF
--- a/capplets/display/display-capplet.ui
+++ b/capplets/display/display-capplet.ui
@@ -94,6 +94,7 @@
                 <property name="receives-default">False</property>
                 <property name="image">apply_button_img</property>
                 <property name="use-underline">True</property>
+                <accelerator key="a" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -110,6 +111,7 @@
                 <property name="receives-default">False</property>
                 <property name="image">window_close_button_img</property>
                 <property name="use-underline">True</property>
+                <accelerator key="c" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
I use a 4k monitor but sometimes as the result of something (in most cases -- segfault of something fullscreen. Like Windows game through Wine) the screen resolution is switching to FHD. In this situation "Monitor Preferences" window is just too big and I don't see the "Apply" button. So I just blindly press TAB until I supposedly on this button and press enter. Totally unfun.
I think the simplest fix to this situation is adding shortcuts (accelerators, I suppose they are called) to these buttons. And this is what I did.

I never used GTK, so not sure how to indicate that there ARE accelerators but at least they are working. Ctrl-A for Apply and Ctrl-C for Cancel.