### PR TITLE
windows: Fix spacing in the Compositing Manager tab

### DIFF
--- a/capplets/windows/window-properties.ui
+++ b/capplets/windows/window-properties.ui
@@ -740,7 +740,7 @@ Author: Robert Buj
               <object class="GtkBox" id="compositing_manager_vbox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="border-width">13</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>


### PR DESCRIPTION
Trivial fix for inconsistent spacing in the *Compositing Manager* tab, which was 1px bigger than the other tabs (and 13 is an unusual amount, where 12 is a common one)