### PR TITLE
 Remove useless match_wm_manager_init function

### DIFF
--- a/capplets/appearance/Makefile.am
+++ b/capplets/appearance/Makefile.am
@@ -40,7 +40,6 @@ mate_appearance_properties_SOURCES = \
 AM_CFLAGS = -DMATE_DESKTOP_USE_UNSTABLE_API
 
 mate_appearance_properties_LDADD = \
-	$(top_builddir)/libwindow-settings/libmate-window-settings.la \
 	$(top_builddir)/capplets/common/libcommon.la \
 	$(MATECC_CAPPLETS_LIBS) \
 	$(FONT_CAPPLET_LIBS) \

--- a/capplets/appearance/appearance-themes.c
+++ b/capplets/appearance/appearance-themes.c
@@ -29,7 +29,6 @@
 #include "appearance-themes.h"
 
 #include <glib/gi18n.h>
-#include <libwindow-settings/mate-wm-manager.h>
 #include <string.h>
 #include <libmate-desktop/mate-desktop-thumbnail.h>
 #include <libmate-desktop/mate-gsettings.h>
@@ -988,7 +987,6 @@ void themes_init(AppearanceData* data)
 
   /* initialise some stuff */
   mate_theme_init ();
-  mate_wm_manager_init ();
 
   data->revert_application_font = NULL;
   data->revert_documents_font = NULL;

--- a/font-viewer/font-view.c
+++ b/font-viewer/font-view.c
@@ -549,6 +549,46 @@ font_view_ensure_model (FontViewApplication *self)
 }
 
 static void
+set_override_background_color (GtkWidget *widget,
+                               GdkRGBA   *rgba)
+{
+    gchar          *css;
+    GtkCssProvider *provider;
+
+    provider = gtk_css_provider_new ();
+
+    css = g_strdup_printf ("* { background-color: %s;}",
+                           gdk_rgba_to_string (rgba));
+    gtk_css_provider_load_from_data (provider, css, -1, NULL);
+    g_free (css);
+
+    gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
+                                    GTK_STYLE_PROVIDER (provider),
+                                    GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    g_object_unref (provider);
+}
+
+static void
+set_override_color (GtkWidget *widget,
+                    GdkRGBA   *rgba)
+{
+    gchar          *css;
+    GtkCssProvider *provider;
+
+    provider = gtk_css_provider_new ();
+
+    css = g_strdup_printf ("* { color: %s;}",
+                           gdk_rgba_to_string (rgba));
+    gtk_css_provider_load_from_data (provider, css, -1, NULL);
+    g_free (css);
+
+    gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
+                                    GTK_STYLE_PROVIDER (provider),
+                                    GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    g_object_unref (provider);
+}
+
+static void
 font_view_application_do_open (FontViewApplication *self,
                                GFile *file,
                                gint face_index)
@@ -587,8 +627,8 @@ font_view_application_do_open (FontViewApplication *self,
 
         self->font_widget = GTK_WIDGET (sushi_font_widget_new (uri, face_index));
 
-        gtk_widget_override_color (self->font_widget, GTK_STATE_NORMAL, &black);
-        gtk_widget_override_background_color (self->font_widget, GTK_STATE_FLAG_NORMAL, &white);
+        set_override_color (self->font_widget, &black);
+        set_override_background_color (self->font_widget, &white);
 
         w = gtk_viewport_new (NULL, NULL);
         gtk_viewport_set_shadow_type (GTK_VIEWPORT (w), GTK_SHADOW_NONE);


### PR DESCRIPTION
 ```appearance``` is no need to call ```match_wm_manager_init``` because we no longer use ```match_wm_manager_get_current``` and ```match_wm_manager_spawn_config_tool_for_current```, This is a useless initialization
Similarly, ```libwindow-settings``` is an outdated and unnecessary API that has not been called by any project