### PR TITLE
appearance: Remove useless match_wm_manager_init function

### DIFF
--- a/capplets/appearance/Makefile.am
+++ b/capplets/appearance/Makefile.am
@@ -40,7 +40,6 @@ mate_appearance_properties_SOURCES = \
 AM_CFLAGS = -DMATE_DESKTOP_USE_UNSTABLE_API
 
 mate_appearance_properties_LDADD = \
-	$(top_builddir)/libwindow-settings/libmate-window-settings.la \
 	$(top_builddir)/capplets/common/libcommon.la \
 	$(MATECC_CAPPLETS_LIBS) \
 	$(FONT_CAPPLET_LIBS) \

--- a/capplets/appearance/appearance-themes.c
+++ b/capplets/appearance/appearance-themes.c
@@ -29,7 +29,6 @@
 #include "appearance-themes.h"
 
 #include <glib/gi18n.h>
-#include <libwindow-settings/mate-wm-manager.h>
 #include <string.h>
 #include <libmate-desktop/mate-desktop-thumbnail.h>
 #include <libmate-desktop/mate-gsettings.h>
@@ -988,7 +987,6 @@ void themes_init(AppearanceData* data)
 
   /* initialise some stuff */
   mate_theme_init ();
-  mate_wm_manager_init ();
 
   data->revert_application_font = NULL;
   data->revert_documents_font = NULL;


### PR DESCRIPTION
 ```appearance``` is no need to call ```match_wm_manager_init``` because we no longer use ```match_wm_manager_get_current``` and ```match_wm_manager_spawn_config_tool_for_current```, This is a useless initialization
Similarly, ```libwindow-settings``` is an outdated and unnecessary API that has not been called by any project