### PR TITLE
Populate in wayland

### DIFF
--- a/capplets/about-me/mate-about-me.desktop.in
+++ b/capplets/about-me/mate-about-me.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=GTK;Settings;X-MATE-PersonalSettings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=mate-control-center;MATE;personal;information;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;

--- a/capplets/accessibility/at-properties/mate-at-properties.desktop.in
+++ b/capplets/accessibility/at-properties/mate-at-properties.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=GTK;Settings;Accessibility;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=mate-control-center;MATE;accessibility;features;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;

--- a/capplets/default-applications/mate-default-applications-properties.desktop.in
+++ b/capplets/default-applications/mate-default-applications-properties.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=GTK;Settings;X-MATE-PersonalSettings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=mate-control-center;MATE;default;preferred;applications;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;

--- a/capplets/network/mate-network-properties.desktop.in
+++ b/capplets/network/mate-network-properties.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=GTK;Settings;X-MATE-NetworkSettings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=mate-control-center;MATE;network;http;socks;proxy;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;

--- a/capplets/system-info/mate-system-info.desktop.in
+++ b/capplets/system-info/mate-system-info.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=GTK;Settings;HardwareSettings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=mate-control-center;MATE;system;preferences;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;

--- a/capplets/time-admin/data/mate-time-admin.desktop.in
+++ b/capplets/time-admin/data/mate-time-admin.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=GTK;Settings;HardwareSettings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=mate-control-center;MATE;clock;date;time;preferences;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;

--- a/shell/matecc.desktop.in
+++ b/shell/matecc.desktop.in
@@ -11,4 +11,4 @@ StartupNotify=false
 Categories=GTK;Settings;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=MATE;control;center;configuration;tool;desktop;preferences;
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;MATE-wayland;


### PR DESCRIPTION
*When running under Wayland, show all of the capplets that are useful in wayland now or which are intended to be in the future

*Show the control center in the main menu when running under wayland. Note that we cannot simply use `XDG_CURRENT_DESKTOP=MATE` or we block users from setting certain GNOME gsettings values differently for x11 and wayland.  We use `XDG_CURRENT_DESKTOP=MATE-wayland` to distinguish the sessions but the control center's .desktop files need to accomodate this.

*This also keeps most x11-only capplets out of the control center when running under wayland 