### PR TITLE
Make systemd optional

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -60,6 +60,7 @@ requires:
     - libxss-dev
     - libxt-dev
     - libpolkit-gobject-1-dev
+    - libsystemd-dev
     - make
     - mate-common
     - policykit-1
@@ -101,6 +102,7 @@ requires:
     - mate-common
     - redhat-rpm-config
     - startup-notification-devel
+    - systemd-devel
     - which
 
   ubuntu:
@@ -135,6 +137,7 @@ requires:
     - libxss-dev
     - libxt-dev
     - libpolkit-gobject-1-dev
+    - libsystemd-dev
     - make
     - mate-common
     - policykit-1

--- a/capplets/system-info/mate-system-info.c
+++ b/capplets/system-info/mate-system-info.c
@@ -132,13 +132,15 @@ static void
 mate_system_info_set_row (MateSystemInfo *info)
 {
     mate_system_info_row_fill (info->hostname_row, _("Device Name"), FALSE);
+# ifdef HAVE_SYSTEMD
     mate_system_info_row_fill (info->hardware_model_row, _("Hardware Model"), TRUE);
+    mate_system_info_row_fill (info->virtualization_row, _("Virtualization"), TRUE);
+# endif
     mate_system_info_row_fill (info->memory_row, _("Memory"), TRUE);
     mate_system_info_row_fill (info->processor_row, _("Processor"), TRUE);
     mate_system_info_row_fill (info->graphics_row, _("Graphics"), TRUE);
     mate_system_info_row_fill (info->disk_row, _("Disk Capacity"), FALSE);
     mate_system_info_row_fill (info->kernel_row, _("Kernel Version"), FALSE);
-    mate_system_info_row_fill (info->virtualization_row, _("Virtualization"), TRUE);
     mate_system_info_row_fill (info->windowing_system_row, _("Windowing System"), TRUE);
     mate_system_info_row_fill (info->mate_version_row, _("MATE Version"), TRUE);
     mate_system_info_row_fill (info->os_name_row, _("OS Name"), TRUE);
@@ -213,6 +215,7 @@ get_system_hostname (void)
 # endif
 }
 
+# ifdef HAVE_SYSTEMD
 static char *
 get_hardware_model (void)
 {
@@ -263,6 +266,7 @@ get_hardware_model (void)
 
     return NULL;
 }
+# endif
 
 static char *
 get_cpu_info (void)
@@ -483,6 +487,7 @@ get_kernel_vesrion (void)
     return g_strdup_printf ("%s %s", un.sysname, un.release);
 }
 
+# ifdef HAVE_SYSTEMD
 static struct {
     const char *id;
     const char *display;
@@ -498,9 +503,7 @@ static struct {
     { "openvz", "OpenVZ" },
     { "lxc", "LXC" },
     { "lxc-libvirt", "LXC (libvirt)" },
-# ifdef HAVE_SYSTEMD
-    { "systemd-nspawn", "systemd (nspawn)" },
-# endif
+    { "systemd-nspawn", "systemd (nspawn)" }
 };
 
 static char *
@@ -567,6 +570,7 @@ get_system_virt (void)
 
     return get_virtualization_label (g_variant_get_string (inner, NULL));
 }
+# endif
 
 static char *
 get_mate_desktop_version ()
@@ -622,7 +626,10 @@ mate_system_info_setup (MateSystemInfo *info)
 {
     g_autofree char *logo_name = NULL;
     g_autofree char *hostname_text = NULL;
+# ifdef HAVE_SYSTEMD
     g_autofree char *hw_model_text = NULL;
+    g_autofree char *virt_text = NULL;
+# endif
     g_autofree char *memory_text = NULL;
     g_autofree char *cpu_text = NULL;
     g_autofree char *os_type_text = NULL;
@@ -630,7 +637,6 @@ mate_system_info_setup (MateSystemInfo *info)
     g_autofree char *disk_text = NULL;
     g_autofree char *kernel_text = NULL;
     g_autofree char *windowing_system_text = NULL;
-    g_autofree char *virt_text = NULL;
     g_autofree char *de_text = NULL;
     g_autofree char *graphics_hardware_string = NULL;
 
@@ -645,6 +651,7 @@ mate_system_info_setup (MateSystemInfo *info)
     label = g_object_get_data (G_OBJECT (info->hostname_row), "labelvalue");
     set_lable_style (label, "gray", 12, hostname_text, FALSE);
 
+# if HAVE_SYSTEMD
     hw_model_text = get_hardware_model ();
     if (hw_model_text != NULL)
     {
@@ -652,7 +659,7 @@ mate_system_info_setup (MateSystemInfo *info)
         label = g_object_get_data (G_OBJECT (info->hardware_model_row), "labelvalue");
         set_lable_style (label, "gray", 12, hw_model_text, FALSE);
     }
-
+# endif
     glibtop_get_mem (&mem);
     memory_text = g_format_size_full (mem.total, G_FORMAT_SIZE_IEC_UNITS);
     label = g_object_get_data (G_OBJECT (info->memory_row), "labelvalue");
@@ -714,7 +721,10 @@ mate_system_info_class_init (MateSystemInfoClass *klass)
     gtk_widget_class_set_template_from_resource (widget_class, "/org/mate/control-center/system-info/mate-system-info.ui");
 
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, hostname_row);
+# ifdef HAVE_SYSTEMD
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, hardware_box);
+    gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, virtualization_row);
+# endif
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, disk_row);
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, mate_version_row);
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, graphics_row);
@@ -725,7 +735,6 @@ mate_system_info_class_init (MateSystemInfoClass *klass)
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, os_name_row);
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, os_type_row);
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, processor_row);
-    gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, virtualization_row);
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, kernel_row);
     gtk_widget_class_bind_template_child (widget_class, MateSystemInfo, windowing_system_row);
 }

--- a/capplets/system-info/mate-system-info.c
+++ b/capplets/system-info/mate-system-info.c
@@ -21,6 +21,7 @@
  *
  */
 #include <gtk/gtk.h>
+#include <glib.h>
 #include <glibtop/fsusage.h>
 #include <glibtop/mountlist.h>
 #include <glibtop/mem.h>
@@ -159,6 +160,7 @@ mate_system_info_set_row (MateSystemInfo *info)
 static char *
 get_system_hostname (void)
 {
+# ifdef HAVE_SYSTEMD
     GDBusProxy         *hostnamed_proxy;
     g_autoptr(GVariant) variant = NULL;
     g_autoptr(GError)   error = NULL; 
@@ -206,6 +208,9 @@ get_system_hostname (void)
         g_object_unref (hostnamed_proxy);
         return g_variant_dup_string (variant, NULL);
     }
+# else
+    return g_strdup (g_get_host_name ());
+# endif
 }
 
 static char *
@@ -493,7 +498,9 @@ static struct {
     { "openvz", "OpenVZ" },
     { "lxc", "LXC" },
     { "lxc-libvirt", "LXC (libvirt)" },
-    { "systemd-nspawn", "systemd (nspawn)" }
+# ifdef HAVE_SYSTEMD
+    { "systemd-nspawn", "systemd (nspawn)" },
+# endif
 };
 
 static char *
@@ -666,7 +673,7 @@ mate_system_info_setup (MateSystemInfo *info)
     kernel_text = get_kernel_vesrion ();
     label = g_object_get_data (G_OBJECT (info->kernel_row), "labelvalue");
     set_lable_style (label, "gray", 12, kernel_text, FALSE);
-
+# ifdef HAVE_SYSTEMD
     virt_text = get_system_virt ();
     if (virt_text != NULL)
     {
@@ -674,6 +681,7 @@ mate_system_info_setup (MateSystemInfo *info)
         label = g_object_get_data (G_OBJECT (info->virtualization_row), "labelvalue");
         set_lable_style (label, "gray", 12, virt_text, FALSE);
     }
+# endif
     windowing_system_text = get_windowing_system ();
     label = g_object_get_data (G_OBJECT (info->windowing_system_row), "labelvalue");
     set_lable_style (label, "gray", 12, windowing_system_text, FALSE);

--- a/configure.ac
+++ b/configure.ac
@@ -327,7 +327,7 @@ Configure summary:
 
         Ayatana AppIndicator (preferred)   $(test "x$enable_appindicator" = xyes && echo no || echo yes)
         Ubuntu AppIndicator (legacy)       $(test "x$enable_appindicator" = xyes && echo yes || echo no)
-	Systemd:                           $(test "x$enable_systemd" = xyes && echo yes || echo no)
+	Systemd:                           ${have_systemd}
 
         Accountsservice:           ${have_accountsservice}
         Native Language support:   ${USE_NLS}

--- a/configure.ac
+++ b/configure.ac
@@ -167,20 +167,6 @@ AC_ARG_ENABLE([libappindicator],
                                                   [enable_appindicator=yes],
                                                   [enable_appindicator=no])])])
 
-AC_ARG_ENABLE([systemd],
-              [AS_HELP_STRING([--enable-systemd[=@<:@no/auto/yes@:>@]],[Use systemd @<:@default=yes@:>@])],
-              [enable_systemd=$enableval],
-              [PKG_CHECK_EXISTS([$SYSTEMD >= $SYSTEMD_REQUIRED],
-                                [enable_systemd=no],
-                                ,
-                                )])
-
-AS_IF([test "x$enable_systemd" = xyes],
-      [AC_MSG_NOTICE([Building with systemd support.])
-       PKG_CHECK_MODULES([SYSTEMD],
-                         [systemd >= $SYSTEMD_REQUIRED],
-                         [AC_DEFINE(HAVE_SYSTEMD, 1, [Have systemd])])])
-
 AS_IF([test "x$enable_appindicator" = xyes],
       [AC_MSG_NOTICE([Buidling against Ubuntu AppIndicator.])
        PKG_CHECK_MODULES([APPINDICATOR],
@@ -190,6 +176,21 @@ AS_IF([test "x$enable_appindicator" = xyes],
        PKG_CHECK_MODULES([APPINDICATOR],
                          [$AYATANA_APPINDICATOR_PKG >= $APPINDICATOR_REQUIRED],
                          [AC_DEFINE(HAVE_AYATANA_APPINDICATOR, 1, [Have Ayatana AppIndicator])])])
+
+have_systemd=no
+AC_ARG_ENABLE(systemd, AS_HELP_STRING([--disable-systemd], [disable systemd support]),enable_systemd="$enableval",enable_systemd=auto)
+if test "x$enable_systemd" != "xno"; then
+	PKG_CHECK_MODULES(SYSTEMD, [libsystemd], [have_systemd=yes],
+	                  [PKG_CHECK_MODULES(SYSTEMD, [libsystemd >= $SYSTEMD_REQUIRED],
+	                  [have_systemd=yes])])
+	if test "x$have_systemd" = xno && test "x$enable_systemd" = xyes; then
+		AC_MSG_ERROR([*** systemd support requested but libraries not found])
+	elif test "x$have_systemd" = xyes; then
+		AC_DEFINE(HAVE_SYSTEMD, 1, [Define if systemd is available])
+	fi
+fi
+
+AM_CONDITIONAL(HAVE_SYSTEMD, [test "$have_systemd" = "yes"])
 
 PKG_CHECK_MODULES(FONT_CAPPLET, $COMMON_MODULES pango)
 PKG_CHECK_MODULES(FONT_VIEWER, $COMMON_MODULES fontconfig freetype2 mate-desktop-2.0)

--- a/configure.ac
+++ b/configure.ac
@@ -121,7 +121,6 @@ PKG_CHECK_MODULES(TYPING, $GMODULE_ADD glib-2.0 >= $GLIB_REQUIRED gio-2.0 gtk+-3
 PKG_CHECK_MODULES(GIO, gio-2.0)
 PKG_CHECK_MODULES(GLIBTOP, libgtop-2.0)
 PKG_CHECK_MODULES(UDISKS, udisks2)
-PKG_CHECK_MODULES(SYSTEMD, systemd >= $SYSTEMD_REQUIRED)
 
 PKG_CHECK_MODULES([DCONF], [dconf >= 0.13.4])
 AC_SUBST(DCONF_CFLAGS)
@@ -167,6 +166,20 @@ AC_ARG_ENABLE([libappindicator],
                                 [PKG_CHECK_EXISTS([$UBUNTU_APPINDICATOR_PKG >= $APPINDICATOR_REQUIRED],
                                                   [enable_appindicator=yes],
                                                   [enable_appindicator=no])])])
+
+AC_ARG_ENABLE([systemd],
+              [AS_HELP_STRING([--enable-systemd[=@<:@no/auto/yes@:>@]],[Use systemd @<:@default=yes@:>@])],
+              [enable_systemd=$enableval],
+              [PKG_CHECK_EXISTS([$SYSTEMD >= $SYSTEMD_REQUIRED],
+                                [enable_systemd=no],
+                                ,
+                                )])
+
+AS_IF([test "x$enable_systemd" = xyes],
+      [AC_MSG_NOTICE([Building with systemd support.])
+       PKG_CHECK_MODULES([SYSTEMD],
+                         [systemd >= $SYSTEMD_REQUIRED],
+                         [AC_DEFINE(HAVE_SYSTEMD, 1, [Have systemd])])])
 
 AS_IF([test "x$enable_appindicator" = xyes],
       [AC_MSG_NOTICE([Buidling against Ubuntu AppIndicator.])
@@ -313,6 +326,7 @@ Configure summary:
 
         Ayatana AppIndicator (preferred)   $(test "x$enable_appindicator" = xyes && echo no || echo yes)
         Ubuntu AppIndicator (legacy)       $(test "x$enable_appindicator" = xyes && echo yes || echo no)
+	Systemd:                           $(test "x$enable_systemd" = xyes && echo yes || echo no)
 
         Accountsservice:           ${have_accountsservice}
         Native Language support:   ${USE_NLS}


### PR DESCRIPTION
There is not much of direct systemd usage in the system-info plugin. This patch suggestion enables building this plugin on system like alpine, voidlinux or gentoo with openrc.

I apologize in advance if this seems sloppy. I am not very knowledgeable with autotools (also, this patch excludes meson).

Suggestions on how to improve the patch are most welcome.