### PR TITLE
appearance in wayland: Support changing theme, icon theme, and font

### DIFF
--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -733,6 +733,7 @@ cb_show_details (GtkWidget *button,
 void font_init(AppearanceData* data)
 {
 	GtkWidget* widget;
+	int ret;
 
 	data->font_details = NULL;
 	data->font_groups = NULL;
@@ -780,6 +781,40 @@ void font_init(AppearanceData* data)
 			  "changed::" WINDOW_TITLE_USES_SYSTEM_KEY,
 			  G_CALLBACK (marco_changed),
 			  data);
+
+	/*In a wayland session we must manage MATE font settings for xwayland
+	 *and also manage GNOME font settings for native wayland applications
+	 *
+	 *First find out if we are running under a wayland session
+	 */
+
+	ret = system ("killall -0 -e Xwayland");
+	/*If we are, set the GNOME interface keys too*/
+	if (ret == 0)
+	{
+		widget = appearance_capplet_get_widget(data, "application_font");
+		g_settings_bind (data->interface_gnome_settings,
+				 GTK_FONT_KEY,
+				 G_OBJECT (widget),
+				 "font-name",
+				 G_SETTINGS_BIND_DEFAULT);
+
+		widget = appearance_capplet_get_widget (data, "document_font");
+		g_settings_bind (data->interface_gnome_settings,
+				 DOCUMENT_FONT_KEY,
+				 G_OBJECT (widget),
+				 "font-name",
+				 G_SETTINGS_BIND_DEFAULT);
+
+/* The monospace font seems to apply properly if and only if set only for MATE
+		widget = appearance_capplet_get_widget (data, "monospace_font");
+		g_settings_bind (data->interface_gnome_settings,
+				 MONOSPACE_FONT_KEY,
+				 G_OBJECT (widget),
+				 "font-name",
+				 G_SETTINGS_BIND_DEFAULT);
+*/
+	}
 
 	g_signal_connect (appearance_capplet_get_widget (data, "add_new_font"), "clicked", G_CALLBACK (cb_add_new_font), data);
 

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -753,7 +753,6 @@ cb_show_details (GtkWidget *button,
 void font_init(AppearanceData* data)
 {
 	GtkWidget* widget;
-	int ret;
 
 	data->font_details = NULL;
 	data->font_groups = NULL;
@@ -804,13 +803,9 @@ void font_init(AppearanceData* data)
 
 	/*In a wayland session we must manage MATE font settings for xwayland
 	 *and also manage GNOME font settings for native wayland applications
-	 *
-	 *First find out if we are running under a wayland session
+	 *so if not running under x11, set the GNOME interface keys too
 	 */
-
-	ret = system ("killall -0 -e Xwayland");
-	/*If we are, set the GNOME interface keys too*/
-	if (ret == 0)
+	if (!(GDK_IS_X11_DISPLAY ((gdk_display_get_default()))))
 	{
 		widget = appearance_capplet_get_widget(data, "application_font");
 		g_settings_bind (data->interface_gnome_settings,

--- a/capplets/appearance/appearance-font.c
+++ b/capplets/appearance/appearance-font.c
@@ -804,8 +804,10 @@ void font_init(AppearanceData* data)
 	/*In a wayland session we must manage MATE font settings for xwayland
 	 *and also manage GNOME font settings for native wayland applications
 	 *so if not running under x11, set the GNOME interface keys too
+	 *Ignore this if for any reason the GNOME schema was not found,
+	 *As we can only set this for compositors using either the MATE or the GNOME gsettings
 	 */
-	if (!(GDK_IS_X11_DISPLAY ((gdk_display_get_default()))))
+	if (data->interface_gnome_settings)
 	{
 		widget = appearance_capplet_get_widget(data, "application_font");
 		g_settings_bind (data->interface_gnome_settings,

--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -31,6 +31,7 @@
 #include "theme-thumbnail.h"
 #include "activate-settings-daemon.h"
 #include "capplet-util.h"
+#include <gdk/gdkx.h>
 
 static AppearanceData *
 init_appearance_data (int *argc, char ***argv, GOptionContext *context)
@@ -56,8 +57,12 @@ init_appearance_data (int *argc, char ***argv, GOptionContext *context)
 
   data->filechooser_settings = g_settings_new (FILECHOOSER_SCHEMA);
   data->interface_settings = g_settings_new (INTERFACE_SCHEMA);
-  /*Loading this unconditionally may be cheaper than another system() call*/
-  data->interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
+
+  if (!(GDK_IS_X11_DISPLAY (gdk_display_get_default())))
+    data->interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
+  else
+    data->interface_gnome_settings = NULL;
+
   data->marco_settings = g_settings_new (MARCO_SCHEMA);
   data->mouse_settings = g_settings_new (MOUSE_SCHEMA);
   data->font_settings = g_settings_new (FONT_RENDER_SCHEMA);

--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -38,6 +38,9 @@ init_appearance_data (int *argc, char ***argv, GOptionContext *context)
   AppearanceData *data = NULL;
   GtkBuilder *ui;
 
+  /*Set the backend to use x11 (must use xwayland in wayland session*/
+  gdk_set_allowed_backends ("x11"); 
+
   theme_thumbnail_factory_init (*argc, *argv);
   capplet_init (context, argc, argv);
   activate_settings_daemon ();
@@ -56,6 +59,8 @@ init_appearance_data (int *argc, char ***argv, GOptionContext *context)
 
   data->filechooser_settings = g_settings_new (FILECHOOSER_SCHEMA);
   data->interface_settings = g_settings_new (INTERFACE_SCHEMA);
+  /*Loading this unconditionally may be cheaper than another system() call*/
+  data->interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
   data->marco_settings = g_settings_new (MARCO_SCHEMA);
   data->mouse_settings = g_settings_new (MOUSE_SCHEMA);
   data->font_settings = g_settings_new (FONT_RENDER_SCHEMA);
@@ -162,10 +167,6 @@ main (int argc, char **argv)
       	N_("[WALLPAPER...]") },
       { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
-
-
-  /*Set the backend to use x11 (must use xwayland in wayland session*/
-  gdk_set_allowed_backends ("x11");
 
   option_context = g_option_context_new (NULL);
   g_option_context_add_main_entries (option_context, option_entries, GETTEXT_PACKAGE);

--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -163,6 +163,10 @@ main (int argc, char **argv)
       { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
 
+
+  /*Set the backend to use x11 (must use xwayland in wayland session*/
+  gdk_set_allowed_backends ("x11");
+
   option_context = g_option_context_new (NULL);
   g_option_context_add_main_entries (option_context, option_entries, GETTEXT_PACKAGE);
 

--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -58,11 +58,20 @@ init_appearance_data (int *argc, char ***argv, GOptionContext *context)
   data->filechooser_settings = g_settings_new (FILECHOOSER_SCHEMA);
   data->interface_settings = g_settings_new (INTERFACE_SCHEMA);
 
+  data->interface_gnome_settings = NULL;
+  /*Load the gnome interface schema if we are running under wayland and it is present*/
   if (!(GDK_IS_X11_DISPLAY (gdk_display_get_default())))
-    data->interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
-  else
-    data->interface_gnome_settings = NULL;
+  {
+    GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
 
+    if (source)
+    {
+      GSettingsSchema *schema = g_settings_schema_source_lookup (source, INTERFACE_GNOME_SCHEMA, TRUE);
+
+      if (schema)
+        data->interface_gnome_settings = g_settings_new_full (schema, NULL, NULL);
+    }
+  }
   data->marco_settings = g_settings_new (MARCO_SCHEMA);
   data->mouse_settings = g_settings_new (MOUSE_SCHEMA);
   data->font_settings = g_settings_new (FONT_RENDER_SCHEMA);

--- a/capplets/appearance/appearance-main.c
+++ b/capplets/appearance/appearance-main.c
@@ -38,9 +38,6 @@ init_appearance_data (int *argc, char ***argv, GOptionContext *context)
   AppearanceData *data = NULL;
   GtkBuilder *ui;
 
-  /*Set the backend to use x11 (must use xwayland in wayland session*/
-  gdk_set_allowed_backends ("x11"); 
-
   theme_thumbnail_factory_init (*argc, *argv);
   capplet_init (context, argc, argv);
   activate_settings_daemon ();

--- a/capplets/appearance/appearance.h
+++ b/capplets/appearance/appearance.h
@@ -58,6 +58,7 @@
 #define GTK_THEME_KEY                "gtk-theme"
 #define ICON_THEME_KEY               "icon-theme"
 #define INTERFACE_SCHEMA             "org.mate.interface"
+#define INTERFACE_GNOME_SCHEMA       "org.gnome.desktop.interface"
 #define MENU_ICONS_KEY               "menus-have-icons"
 #define MONOSPACE_FONT_KEY           "monospace-font-name"
 #define TOOLBAR_STYLE_KEY            "toolbar-style"
@@ -92,6 +93,10 @@ typedef struct {
 	GSettings* caja_settings;
 	GSettings* filechooser_settings;
 	GSettings* interface_settings;
+	/*We have to accomodate wayland theme setting here
+	 *whether we are using it or not
+	 */
+	GSettings* interface_gnome_settings;
 	GSettings* marco_settings;
 	GSettings* mouse_settings;
 	GSettings* font_settings;

--- a/capplets/common/mate-theme-apply.c
+++ b/capplets/common/mate-theme-apply.c
@@ -56,18 +56,14 @@ mate_meta_theme_set (MateThemeMetaInfo *meta_theme_info)
   GSettings *notification_settings = NULL;
   gchar *old_key;
   gint old_key_int;
-  gboolean wayland;
 
-  /*Find out whether we are running under wayland or x11 */
-
-  if (GDK_IS_X11_DISPLAY ((gdk_display_get_default())))
-    wayland = FALSE;
-
+  /*We only want to touch GNOME settings under Wayland */
+  if (GDK_IS_X11_DISPLAY (gdk_display_get_default()))
+    interface_gnome_settings = NULL;
   else
-    wayland = TRUE;
+    interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
 
   interface_settings = g_settings_new (INTERFACE_SCHEMA);
-  interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
   marco_settings = g_settings_new (MARCO_SCHEMA);
   mouse_settings = g_settings_new (MOUSE_SCHEMA);
 
@@ -82,7 +78,7 @@ mate_meta_theme_set (MateThemeMetaInfo *meta_theme_info)
     {
       g_settings_set_string (interface_settings, GTK_THEME_KEY, meta_theme_info->gtk_theme_name);
 
-      if (wayland == TRUE)
+      if (interface_gnome_settings)
           g_settings_set_string (interface_gnome_settings, 
                                  GTK_THEME_KEY, meta_theme_info->gtk_theme_name);
 
@@ -123,7 +119,7 @@ mate_meta_theme_set (MateThemeMetaInfo *meta_theme_info)
   if (compare (old_key, meta_theme_info->icon_theme_name))
     {
       g_settings_set_string (interface_settings, ICON_THEME_KEY, meta_theme_info->icon_theme_name);
-      if (wayland == TRUE)
+      if (interface_gnome_settings)
         g_settings_set_string (interface_gnome_settings,
                              ICON_THEME_KEY, meta_theme_info->icon_theme_name);
     }
@@ -148,7 +144,7 @@ mate_meta_theme_set (MateThemeMetaInfo *meta_theme_info)
   if (compare (old_key, meta_theme_info->cursor_theme_name))
     {
       g_settings_set_string (mouse_settings, CURSOR_THEME_KEY, meta_theme_info->cursor_theme_name);
-      if (wayland == TRUE)
+      if (interface_gnome_settings)
       {
         /*Note that this key is in a different place in GNOME than it is in MATE*/
         g_settings_set_string (interface_gnome_settings,

--- a/capplets/common/mate-theme-apply.c
+++ b/capplets/common/mate-theme-apply.c
@@ -50,14 +50,13 @@ void
 mate_meta_theme_set (MateThemeMetaInfo *meta_theme_info)
 {
   GSettings *interface_settings;
-  GSettings *interface_gnome_settings;
+  GSettings *interface_gnome_settings = NULL;
   GSettings *marco_settings;
   GSettings *mouse_settings;
   GSettings *notification_settings = NULL;
   gchar *old_key;
   gint old_key_int;
 
-  interface_gnome_settings = NULL;
   /*Load the gnome interface schema if we are running under wayland and it is present*/
   if (!(GDK_IS_X11_DISPLAY (gdk_display_get_default())))
   {

--- a/capplets/common/mate-theme-apply.c
+++ b/capplets/common/mate-theme-apply.c
@@ -57,11 +57,20 @@ mate_meta_theme_set (MateThemeMetaInfo *meta_theme_info)
   gchar *old_key;
   gint old_key_int;
 
-  /*We only want to touch GNOME settings under Wayland */
-  if (GDK_IS_X11_DISPLAY (gdk_display_get_default()))
-    interface_gnome_settings = NULL;
-  else
-    interface_gnome_settings = g_settings_new (INTERFACE_GNOME_SCHEMA);
+  interface_gnome_settings = NULL;
+  /*Load the gnome interface schema if we are running under wayland and it is present*/
+  if (!(GDK_IS_X11_DISPLAY (gdk_display_get_default())))
+  {
+    GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
+
+    if (source)
+    {
+      GSettingsSchema *schema = g_settings_schema_source_lookup (source, INTERFACE_GNOME_SCHEMA, TRUE);
+
+      if (schema)
+        interface_gnome_settings = g_settings_new_full (schema, NULL, NULL);
+    }
+  }
 
   interface_settings = g_settings_new (INTERFACE_SCHEMA);
   marco_settings = g_settings_new (MARCO_SCHEMA);


### PR DESCRIPTION
*If we are in a wayland session, write the gtk theme and icon theme to both org.mate and org.gnome *This changes wayland and xwayland themes simultaniously *startup with x11 backend, if we are under wayland without xwayland we don't have mate-settings-daemon anyway