### PR TITLE
Implement GitHub Actions Workflow to Automatically Close Stale Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. If the issue is still valid, please comment or update it. Otherwise, it will be closed in 7 days.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. If the pull request is still valid, please comment or update it. Otherwise, it will be closed in 7 days.'
+          days-before-stale: 365 # Number of days of inactivity before an issue is marked as stale
+          days-before-close: 7 # Number of days to wait to close an issue after it has been marked as stale
+          exempt-issue-labels: 'never-stale' # Label to exempt issues from being marked as stale
+          exempt-pr-labels: 'never-stale' # Label to exempt pull requests from being marked as stale


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow designed to automatically manage and close stale issues (issues where the last activity is older than 365 days) in our repository. This workflow will help us maintain a clean and manageable issue tracker by automatically marking issues as stale after a period of inactivity and subsequently closing them if no further activity occurs.

I plan to add this to every repo. Issues can still be labeled with a "do not stale" label, to prevent them from being automatically closed.

See https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues for a reference.