### PR TITLE
fix: support change password with passwdqc

### DIFF
--- a/capplets/about-me/mate-about-me-password.c
+++ b/capplets/about-me/mate-about-me-password.c
@@ -474,7 +474,7 @@ io_watch_stdout (GIOChannel *source, GIOCondition condition, PasswordDialog *pdi
 				/* Which response did we get? */
 				passdlg_set_busy (pdialog, FALSE);
 
-				if (g_strrstr (str->str, "New password: ") != NULL) {
+				if ((g_strrstr (str->str, "New password: ") != NULL) || (g_strrstr (str->str, "Enter new password: ") != NULL)) {
 					/* Authentication successful */
 
 					authenticated_user (pdialog, FALSE);


### PR DESCRIPTION
This one was quite tricky ... On systems where pam_passwdqc is installed the prompt for password after succesfully authenticating is not:

```
New password:
```

But:

```
Enter new password:
```

See:

https://github.com/openwall/passwdqc/blob/7bf266fcf6ce9782b73722664e36dabd68f48c48/pam_passwdqc.c#L64

passwdqc is installed by default in Gentoo, but might be also installed in other Linux distributions.