### PR TITLE
keyboard: option to show/select extra layouts

### DIFF
--- a/capplets/keyboard/mate-keyboard-properties-dialog.ui
+++ b/capplets/keyboard/mate-keyboard-properties-dialog.ui
@@ -830,6 +830,22 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+						<child>
+						  <object class="GtkCheckButton" id="chk_load_extra_items">
+							<property name="label" translatable="yes">_Include less-common layouts in the selections list</property>
+							<property name="visible">True</property>
+							<property name="can_focus">True</property>
+							<property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="use-underline">True</property>
+							<property name="draw_indicator">True</property>
+						  </object>
+						  <packing>
+							<property name="expand">False</property>
+							<property name="fill">False</property>
+							<property name="position">2</property>
+						  </packing>
+						</child>
                         <child>
                           <object class="GtkCheckButton" id="chk_separate_group_per_window">
                             <property name="label" translatable="yes">_Separate layout for each window</property>
@@ -843,7 +859,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -859,7 +875,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </object>

--- a/capplets/keyboard/mate-keyboard-properties-xkb.c
+++ b/capplets/keyboard/mate-keyboard-properties-xkb.c
@@ -150,6 +150,18 @@ chk_separate_group_per_window_toggled (GSettings * settings,
 }
 
 static void
+chk_load_extra_items_toggled (GSettings * settings,
+				       gchar * key,
+				       GtkBuilder * dialog)
+{
+	matekbd_desktop_config_load_from_gsettings (&desktop_config);
+
+	xkl_config_registry_load (config_registry, desktop_config.load_extra_items);
+
+	xkb_layouts_fill_selected_tree (dialog);
+}
+
+static void
 chk_new_windows_inherit_layout_toggled (GtkWidget *
 					chk_new_windows_inherit_layout,
 					GtkBuilder * dialog)
@@ -192,6 +204,18 @@ setup_xkb_tabs (GtkBuilder * dialog)
 					 "changed::group-per-window",
 					 G_CALLBACK (chk_separate_group_per_window_toggled),
 					 dialog);
+
+	g_settings_bind (xkb_general_settings,
+					 "load-extra-items",
+					 WID ("chk_load_extra_items"),
+					 "active",
+					 G_SETTINGS_BIND_DEFAULT);
+
+	g_signal_connect (xkb_general_settings,
+					 "changed::load-extra-items",
+					 G_CALLBACK (chk_load_extra_items_toggled),
+					 dialog);
+
 
 #ifdef HAVE_X11_EXTENSIONS_XKB_H
 	if (strcmp (xkl_engine_get_backend_name (engine), "XKB"))


### PR DESCRIPTION
- add new checkbox "Include less-common layouts in the selections list" 
![image](https://github.com/user-attachments/assets/560dbda9-44ec-4d6f-967c-ae69ff54ae37)

- switch /org/mate/desktop/peripherals/keyboard/general/load-extra-items
- it is a port/re-work of https://github.com/linuxmint/cinnamon-control-center/commit/d961517fd248f62dc1dc8040731c48822dd68891#diff-7525274c9dc606950625f46b7d8150e4223d7ad4eb9fae59d700d45539c4ccddR196

purpose of the feature. 
it is really hard to know what option controls that extra layout list, I had spent hours groking why my laptop can show them and desktop can't 
so probably it will be useful for newbies and such 

P.S. please be extra careful with review - this is my first ever PR into gtk/mate code