### PR TITLE
Fix libsystemd auto-detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,16 +179,11 @@ AS_IF([test "x$enable_appindicator" = xyes],
 
 have_systemd=no
 AC_ARG_ENABLE(systemd, AS_HELP_STRING([--disable-systemd], [disable systemd support]),enable_systemd="$enableval",enable_systemd=auto)
-if test "x$enable_systemd" != "xno"; then
-	PKG_CHECK_MODULES(SYSTEMD, [libsystemd], [have_systemd=yes],
-	                  [PKG_CHECK_MODULES(SYSTEMD, [libsystemd >= $SYSTEMD_REQUIRED],
-	                  [have_systemd=yes])])
-	if test "x$have_systemd" = xno && test "x$enable_systemd" = xyes; then
-		AC_MSG_ERROR([*** systemd support requested but libraries not found])
-	elif test "x$have_systemd" = xyes; then
-		AC_DEFINE(HAVE_SYSTEMD, 1, [Define if systemd is available])
-	fi
-fi
+AS_CASE(["$enable_systemd"],
+        [yes], [PKG_CHECK_MODULES(SYSTEMD, [libsystemd >= $SYSTEMD_REQUIRED], [have_systemd=yes])],
+        [auto], [PKG_CHECK_MODULES(SYSTEMD, [libsystemd >= $SYSTEMD_REQUIRED], [have_systemd=yes], [have_systemd=no])],
+        [have_systemd=no])
+AS_IF([test "x$have_systemd" = xyes], [AC_DEFINE(HAVE_SYSTEMD, 1, [Define if systemd is available])])
 
 AM_CONDITIONAL(HAVE_SYSTEMD, [test "$have_systemd" = "yes"])
 


### PR DESCRIPTION
Properly handle missing libsystemd when enable-systemd=auto, which is even the default for this switch.

Without this, one had to explicitly give `--disable-systemd` despite the what the help text stated.

---

The reason is that `PKG_CHECK_MODULES()` errors-out if it is not given a 4th argument (action-is-not-found).  The ideal solution for this is however to call with the right arguments depending on whether we want a hard or soft failure, because in case of hard failure `PKG_CHECK_MODULES()` gives a more useful error message than what we would do ourselves.