### PR TITLE
Improve accessibility of the keybindings properties dialog

### DIFF
--- a/capplets/keybindings/eggcellrendererkeys.c
+++ b/capplets/keybindings/eggcellrendererkeys.c
@@ -627,6 +627,8 @@ egg_cell_renderer_keys_start_editing (GtkCellRenderer      *cell,
                     keys);
 
   eventbox = g_object_new (pointless_eventbox_subclass_get_type (),
+			   "tooltip-text", _("Press the keys for the new accelerator, Backspace to clear, or Escape to cancel edition"),
+			   "can-focus", TRUE,
                            NULL);
   keys->edit_widget = eventbox;
   g_object_add_weak_pointer (G_OBJECT (keys->edit_widget),

--- a/capplets/keybindings/mate-keybinding-properties.ui
+++ b/capplets/keybindings/mate-keybinding-properties.ui
@@ -336,7 +336,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">To edit a shortcut key, double-click on the corresponding row and type a new key combination, or press backspace to clear.</property>
+                        <property name="label" translatable="yes">To edit a shortcut key, double-click or press Space or Enter on the corresponding row and type a new key combination, or press backspace to clear.</property>
                         <property name="wrap">True</property>
                       </object>
                       <packing>


### PR DESCRIPTION
* Hint to the keyboard navigation in the help text
* Present something to the screen reader when waiting for a new shortcut
* Fix the value screen readers see for the shortcut of group rows (which is visually empty, but had seemingly random values for the screen readers)

@joanmarie @shindere Hope that fixes https://www.freelists.org/post/orca/Could-Orca-be-more-accurate-in-the-keyboard-shortcut-system-window,4  Could you give it a spin?

However, I couldn't seem to get the help-text stuff to work, even with Orca 48/AT-SPI 2.56 from Debian Bookworm's backports.
I hope the updated help text and tooltip are enough; and there's an additional fix for group rows.