### PR TITLE
font-viewer: Bring the window to the front when triggering the app

### DIFF
--- a/font-viewer/font-view.c
+++ b/font-viewer/font-view.c
@@ -658,6 +658,8 @@ font_view_application_do_open (FontViewApplication *self,
 
     gtk_widget_show_all (self->swin_preview);
     gtk_notebook_set_current_page (GTK_NOTEBOOK (self->notebook), 1);
+
+    gtk_window_present (GTK_WINDOW (self->main_window));
 }
 
 static gboolean
@@ -933,6 +935,8 @@ font_view_application_activate (GApplication *application)
 
     G_APPLICATION_CLASS (font_view_application_parent_class)->activate (application);
     font_view_application_do_overview (self);
+
+    gtk_window_present (GTK_WINDOW (self->main_window));
 }
 
 static void


### PR DESCRIPTION
If the app is already open, we need to tell the desktop that the window has been triggered, so it can either bring it to front, or notify the user the window claims attention.

This fixes the cases where the font viewer is already open and gets triggered again, e.g. by opening a font or launching it directly.