### PR TITLE
Update window layout

### DIFF
--- a/capplets/default-applications/mate-default-applications-properties.ui
+++ b/capplets/default-applications/mate-default-applications-properties.ui
@@ -28,6 +28,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area">
             <property name="visible">True</property>


### PR DESCRIPTION
This old PR align bottom spacing between _notebook_ & _buttons_ for **mate-default-applications-properties** like in **mate-appearance-properties**.

before:

<img width="458" height="125" alt="image" src="https://github.com/user-attachments/assets/a80b015f-272c-44d1-a5b4-b519155ebf51" />

---

after:

<img width="459" height="456" alt="image" src="https://github.com/user-attachments/assets/acb99b40-249a-460e-b3be-89d5dc13606c" />
