### PR TITLE
appearance: verify if theme is GTK3

### DIFF
--- a/capplets/appearance/appearance-style.c
+++ b/capplets/appearance/appearance-style.c
@@ -805,7 +805,7 @@ create_thumbnail (const gchar *name, GdkPixbuf *default_thumb, AppearanceData *d
   } else if (default_thumb == data->gtk_theme_icon) {
     MateThemeInfo *info;
     info = mate_theme_info_find (name);
-    if (info != NULL && info->has_gtk) {
+    if (info != NULL && (info->has_gtk2 || info->has_gtk3)) {
       generate_gtk_theme_thumbnail_async (info,
           (ThemeThumbnailFunc) gtk_theme_thumbnail_cb, data, NULL);
     }
@@ -829,17 +829,28 @@ changed_on_disk_cb (MateThemeCommonInfo *theme,
     MateThemeInfo *info = (MateThemeInfo *) theme;
 
     if (change_type == MATE_THEME_CHANGE_DELETED) {
-      if (element_type & MATE_THEME_GTK_2)
-        remove_from_treeview ("gtk_themes_list", info->name, data);
+      if (element_type & (MATE_THEME_GTK_2 | MATE_THEME_GTK_3)) {
+        /* Only remove from list if neither GTK2 nor GTK3 theme remains */
+        if (!info->has_gtk2 && !info->has_gtk3)
+          remove_from_treeview ("gtk_themes_list", info->name, data);
+      }
       if (element_type & MATE_THEME_MARCO)
         remove_from_treeview ("window_themes_list", info->name, data);
 
     } else {
-      if (element_type & MATE_THEME_GTK_2) {
-        if (change_type == MATE_THEME_CHANGE_CREATED)
-          add_to_treeview ("gtk_themes_list", info->name, info->name, data->gtk_theme_icon, data);
-        else if (change_type == MATE_THEME_CHANGE_CHANGED)
+      if (element_type & (MATE_THEME_GTK_2 | MATE_THEME_GTK_3)) {
+        if (change_type == MATE_THEME_CHANGE_CREATED) {
+          GtkTreeView *tv = GTK_TREE_VIEW (appearance_capplet_get_widget (data, "gtk_themes_list"));
+          GtkTreeModel *model = gtk_tree_model_sort_get_model (GTK_TREE_MODEL_SORT (gtk_tree_view_get_model (tv)));
+          GtkTreeIter iter;
+
+          if (theme_find_in_model (model, info->name, &iter))
+            update_in_treeview ("gtk_themes_list", info->name, info->name, data);
+          else
+            add_to_treeview ("gtk_themes_list", info->name, info->name, data->gtk_theme_icon, data);
+        } else if (change_type == MATE_THEME_CHANGE_CHANGED) {
           update_in_treeview ("gtk_themes_list", info->name, info->name, data);
+        }
 
         generate_gtk_theme_thumbnail_async (info,
             (ThemeThumbnailFunc) gtk_theme_thumbnail_cb, data, NULL);
@@ -903,7 +914,7 @@ prepare_list (AppearanceData *data, GtkWidget *list, ThemeType type, GCallback c
   switch (type)
   {
     case THEME_TYPE_GTK:
-      themes = mate_theme_info_find_by_type (MATE_THEME_GTK_2);
+      themes = mate_theme_info_find_by_type (MATE_THEME_GTK_2 | MATE_THEME_GTK_3);
       thumbnail = data->gtk_theme_icon;
       settings = data->interface_settings;
       key = GTK_THEME_KEY;

--- a/capplets/common/mate-theme-info.c
+++ b/capplets/common/mate-theme-info.c
@@ -73,6 +73,7 @@ typedef struct _ThemeCallbackData {
 typedef struct {
   GFileMonitor  *common_theme_dir_handle;
   GFileMonitor  *gtk2_dir_handle;
+  GFileMonitor  *gtk3_dir_handle;
   GFileMonitor  *keybinding_dir_handle;
   GFileMonitor  *marco_dir_handle;
   gint           priority;
@@ -668,6 +669,8 @@ handle_change_signal (gpointer             data,
   else if (theme->type == MATE_THEME_TYPE_REGULAR) {
     if (element_type & MATE_THEME_GTK_2)
       element_str = "gtk-2";
+    else if (element_type & MATE_THEME_GTK_3)
+      element_str = "gtk-3";
     else if (element_type & MATE_THEME_GTK_2_KEYBINDING)
       element_str = "keybinding";
     else if (element_type & MATE_THEME_MARCO)
@@ -727,7 +730,9 @@ update_theme_index (GFile            *index_uri,
       theme_info->readable_name = g_strdup (theme_info->name);
       theme_info->priority = priority;
       if (key_element & MATE_THEME_GTK_2)
-        theme_info->has_gtk = TRUE;
+        theme_info->has_gtk2 = TRUE;
+      else if (key_element & MATE_THEME_GTK_3)
+        theme_info->has_gtk3 = TRUE;
       else if (key_element & MATE_THEME_GTK_2_KEYBINDING)
         theme_info->has_keybinding = TRUE;
       else if (key_element & MATE_THEME_MARCO)
@@ -741,8 +746,11 @@ update_theme_index (GFile            *index_uri,
     gboolean theme_used_to_exist = FALSE;
 
     if (key_element & MATE_THEME_GTK_2) {
-      theme_used_to_exist = theme_info->has_gtk;
-      theme_info->has_gtk = (theme_exists != FALSE);
+      theme_used_to_exist = theme_info->has_gtk2;
+      theme_info->has_gtk2 = (theme_exists != FALSE);
+    } else if (key_element & MATE_THEME_GTK_3) {
+      theme_used_to_exist = theme_info->has_gtk3;
+      theme_info->has_gtk3 = (theme_exists != FALSE);
     } else if (key_element & MATE_THEME_GTK_2_KEYBINDING) {
       theme_used_to_exist = theme_info->has_keybinding;
       theme_info->has_keybinding = (theme_exists != FALSE);
@@ -751,7 +759,7 @@ update_theme_index (GFile            *index_uri,
       theme_info->has_marco = (theme_exists != FALSE);
     }
 
-    if (!theme_info->has_marco && !theme_info->has_keybinding && !theme_info->has_gtk) {
+    if (!theme_info->has_marco && !theme_info->has_keybinding && !theme_info->has_gtk2 && !theme_info->has_gtk3) {
       g_hash_table_remove (theme_hash_by_uri, common_theme_dir);
       remove_theme_from_hash_by_name (theme_hash_by_name, theme_info);
     }
@@ -764,7 +772,7 @@ update_theme_index (GFile            *index_uri,
       handle_change_signal (theme_info, MATE_THEME_CHANGE_DELETED, key_element);
     }
 
-    if (!theme_info->has_marco && !theme_info->has_keybinding && !theme_info->has_gtk) {
+    if (!theme_info->has_marco && !theme_info->has_keybinding && !theme_info->has_gtk2 && !theme_info->has_gtk3) {
       mate_theme_info_free (theme_info);
     }
   }
@@ -780,6 +788,15 @@ update_gtk2_index (GFile *gtk2_index_uri,
 {
   update_theme_index (gtk2_index_uri,
                       MATE_THEME_GTK_2,
+                      priority);
+}
+
+static void
+update_gtk3_index (GFile *gtk3_index_uri,
+                   gint   priority)
+{
+  update_theme_index (gtk3_index_uri,
+                      MATE_THEME_GTK_3,
                       priority);
 }
 
@@ -935,6 +952,25 @@ gtk2_dir_changed (GFileMonitor              *monitor,
 }
 
 static void
+gtk3_dir_changed (GFileMonitor              *monitor,
+                  GFile                     *file,
+                  GFile                     *other_file,
+                  GFileMonitorEvent          event_type,
+                  CommonThemeDirMonitorData *monitor_data)
+{
+  gchar *affected_file;
+
+  affected_file = g_file_get_basename (file);
+
+  /* The only file we care about is gtk.css */
+  if (!strcmp (affected_file, "gtk.css")) {
+    update_gtk3_index (file, monitor_data->priority);
+  }
+
+  g_free (affected_file);
+}
+
+static void
 keybinding_dir_changed (GFileMonitor              *monitor,
                         GFile                     *file,
                         GFile                     *other_file,
@@ -1065,6 +1101,23 @@ add_common_theme_dir_monitor (GFile                      *theme_dir_uri,
   monitor_data->gtk2_dir_handle = monitor;
   g_object_unref (subdir);
 
+  /* gtk-3 theme subdir */
+  subdir = g_file_get_child (theme_dir_uri, "gtk-3.0");
+  uri = g_file_get_child (subdir, "gtk.css");
+  if (g_file_query_exists (uri, NULL)) {
+    update_gtk3_index (uri, monitor_data->priority);
+  }
+  g_object_unref (uri);
+
+  monitor = g_file_monitor_directory (subdir, G_FILE_MONITOR_NONE, NULL, NULL);
+  if (monitor != NULL) {
+    g_signal_connect (monitor, "changed",
+                      (GCallback) gtk3_dir_changed,
+                      monitor_data);
+  }
+  monitor_data->gtk3_dir_handle = monitor;
+  g_object_unref (subdir);
+
   /* keybinding theme subdir */
   subdir = g_file_get_child (theme_dir_uri, "gtk-2.0-key");
   uri = g_file_get_child (subdir, "gtkrc");
@@ -1140,6 +1193,7 @@ remove_common_theme_dir_monitor (CommonThemeDirMonitorData *monitor_data)
 {
   g_file_monitor_cancel (monitor_data->common_theme_dir_handle);
   g_file_monitor_cancel (monitor_data->gtk2_dir_handle);
+  g_file_monitor_cancel (monitor_data->gtk3_dir_handle);
   g_file_monitor_cancel (monitor_data->keybinding_dir_handle);
   g_file_monitor_cancel (monitor_data->marco_dir_handle);
 }
@@ -1364,7 +1418,8 @@ mate_theme_info_find_by_type_helper (gpointer key,
     MateThemeInfo *theme_info = list->data;
 
     if ((elements & MATE_THEME_MARCO && theme_info->has_marco) ||
-        (elements & MATE_THEME_GTK_2 && theme_info->has_gtk) ||
+        (elements & MATE_THEME_GTK_2 && theme_info->has_gtk2) ||
+        (elements & MATE_THEME_GTK_3 && theme_info->has_gtk3) ||
         (elements & MATE_THEME_GTK_2_KEYBINDING && theme_info->has_keybinding)) {
       hash_data->list = g_list_prepend (hash_data->list, theme_info);
       return;
@@ -1601,7 +1656,7 @@ mate_theme_meta_info_validate (const MateThemeMetaInfo   *info,
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   theme = mate_theme_info_find (info->gtk_theme_name);
-  if (!theme || !theme->has_gtk) {
+  if (!theme || !(theme->has_gtk2 || theme->has_gtk3)) {
     g_set_error (error, MATE_THEME_ERROR, MATE_THEME_ERROR_GTK_THEME_NOT_AVAILABLE,
                  _("This theme will not look as intended because the required GTK+ theme '%s' is not installed."),
                 info->gtk_theme_name);

--- a/capplets/common/mate-theme-info.h
+++ b/capplets/common/mate-theme-info.h
@@ -45,7 +45,8 @@ typedef enum {
 typedef enum {
 	MATE_THEME_MARCO = 1 << 0,
 	MATE_THEME_GTK_2 = 1 << 1,
-	MATE_THEME_GTK_2_KEYBINDING = 1 << 2
+	MATE_THEME_GTK_2_KEYBINDING = 1 << 2,
+	MATE_THEME_GTK_3 = 1 << 3
 } MateThemeElement;
 
 typedef struct _MateThemeCommonInfo MateThemeCommonInfo;
@@ -70,7 +71,8 @@ struct _MateThemeInfo
 	gint priority;
 	gboolean hidden;
 
-	guint has_gtk : 1;
+	guint has_gtk2 : 1;
+	guint has_gtk3 : 1;
 	guint has_keybinding : 1;
 	guint has_marco : 1;
 };


### PR DESCRIPTION
mate-appearance-properties only looked for a gtk-2.0/gtkrc file when deciding whether a theme was installed, so GTK3 themes were reported as not installed.

This adds a monitor for the gtk-3.0/gtk.css file to validate whether the theme is GTK3.

Fixes mate-desktop/mate-themes#276